### PR TITLE
sv_gameplayfix_stepmultipletimes 1: Make stepping up while jumping reliable

### DIFF
--- a/sv_phys.c
+++ b/sv_phys.c
@@ -1303,7 +1303,8 @@ static int SV_FlyMove (prvm_edict_t *ent, float time, qbool applygravity, float 
 			}
 			//Con_Printf("%f %f %f : ", PRVM_serveredictvector(ent, origin)[0], PRVM_serveredictvector(ent, origin)[1], PRVM_serveredictvector(ent, origin)[2]);
 			// accept the new position if it made some progress...
-			if (fabs(PRVM_serveredictvector(ent, origin)[0] - org[0]) >= 0.03125 || fabs(PRVM_serveredictvector(ent, origin)[1] - org[1]) >= 0.03125)
+			// previously this checked if absolute distance >= 0.03125 which made stepping up unreliable
+			if (PRVM_serveredictvector(ent, origin)[0] - org[0] || PRVM_serveredictvector(ent, origin)[1] - org[1])
 			{
 				//Con_Printf("accepted (delta %f %f %f)\n", PRVM_serveredictvector(ent, origin)[0] - org[0], PRVM_serveredictvector(ent, origin)[1] - org[1], PRVM_serveredictvector(ent, origin)[2] - org[2]);
 				trace = steptrace2;


### PR DESCRIPTION
When the player is hard up against a solid surface trying to climb up, they are blocked from gaining any significant speed by the solid, so the distance they could potentially move into the solid at that speed can be well under 0.03125 units, causing the step up to fail.

The same can happen when the player is stepping up with less than 0.03125 units of distance left on their move, causing them to stop dead when climbing stairs at speed with `sv_gameplayfix_stepmultipletimes 1`.

Fixes #8 Stepping up is unreliable