### PR TITLE
Make trace entity culling optional for spectators

### DIFF
--- a/server.h
+++ b/server.h
@@ -581,7 +581,7 @@ int SV_EntitiesInBox(const vec3_t mins, const vec3_t maxs, int maxedicts, prvm_e
 
 qbool SV_CanSeeBox(int numsamples, vec_t eyejitter, vec_t enlarge, vec_t entboxexpand, vec3_t eye, vec3_t entboxmins, vec3_t entboxmaxs);
 
-void SV_MarkWriteEntityStateToClient(entity_state_t *s);
+void SV_MarkWriteEntityStateToClient(entity_state_t *s, client_t *client);
 
 void SV_SendServerinfo(client_t *client);
 void SV_WriteEntitiesToClient(client_t *client, prvm_edict_t *clent, sizebuf_t *msg, int maxsize);

--- a/sv_ents.c
+++ b/sv_ents.c
@@ -395,7 +395,7 @@ void SV_WriteEntitiesToClient(client_t *client, prvm_edict_t *clent, sizebuf_t *
 	sv.sententitiesmark++;
 
 	for (i = 0;i < sv.numsendentities;i++)
-		SV_MarkWriteEntityStateToClient(sv.sendentities + i);
+		SV_MarkWriteEntityStateToClient(sv.sendentities + i, client);
 
 	numsendstates = 0;
 	numcsqcsendstates = 0;

--- a/sv_main.c
+++ b/sv_main.c
@@ -92,6 +92,7 @@ cvar_t sv_cullentities_trace_entityocclusion = {CF_SERVER, "sv_cullentities_trac
 cvar_t sv_cullentities_trace_samples = {CF_SERVER, "sv_cullentities_trace_samples", "2", "number of samples to test for entity culling"};
 cvar_t sv_cullentities_trace_samples_extra = {CF_SERVER, "sv_cullentities_trace_samples_extra", "2", "number of samples to test for entity culling when the entity affects its surroundings by e.g. dlight"};
 cvar_t sv_cullentities_trace_samples_players = {CF_SERVER, "sv_cullentities_trace_samples_players", "8", "number of samples to test for entity culling when the entity is a player entity"};
+cvar_t sv_cullentities_trace_spectators = {CF_SERVER, "sv_cullentities_trace_spectators", "0", "enables trace entity culling for clients that are spectating"};
 cvar_t sv_debugmove = {CF_SERVER | CF_NOTIFY, "sv_debugmove", "0", "disables collision detection optimizations for debugging purposes"};
 cvar_t sv_echobprint = {CF_SERVER | CF_ARCHIVE, "sv_echobprint", "1", "prints gamecode bprint() calls to server console"};
 cvar_t sv_edgefriction = {CF_SERVER, "edgefriction", "1", "how much you slow down when nearing a ledge you might fall off, multiplier of sv_friction (Quake used 2, QuakeWorld used 1 due to a bug in physics code)"};
@@ -590,6 +591,7 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_cullentities_trace_samples);
 	Cvar_RegisterVariable (&sv_cullentities_trace_samples_extra);
 	Cvar_RegisterVariable (&sv_cullentities_trace_samples_players);
+	Cvar_RegisterVariable (&sv_cullentities_trace_spectators);
 	Cvar_RegisterVariable (&sv_debugmove);
 	Cvar_RegisterVariable (&sv_echobprint);
 	Cvar_RegisterVariable (&sv_edgefriction);

--- a/sv_send.c
+++ b/sv_send.c
@@ -34,6 +34,7 @@ extern cvar_t sv_cullentities_trace_samples_players;
 extern cvar_t sv_cullentities_trace_eyejitter;
 extern cvar_t sv_cullentities_trace_expand;
 extern cvar_t sv_cullentities_trace_delay_players;
+extern cvar_t sv_cullentities_trace_spectators;
 
 /*
 =============================================================================
@@ -859,7 +860,7 @@ qbool SV_CanSeeBox(int numtraces, vec_t eyejitter, vec_t enlarge, vec_t entboxex
 	return false;
 }
 
-void SV_MarkWriteEntityStateToClient(entity_state_t *s)
+void SV_MarkWriteEntityStateToClient(entity_state_t *s, client_t *client)
 {
 	prvm_prog_t *prog = SVVM_prog;
 	int isbmodel;
@@ -906,7 +907,7 @@ void SV_MarkWriteEntityStateToClient(entity_state_t *s)
 			// tag attached entities simply check their parent
 			if (!sv.sendentitiesindex[s->tagentity])
 				return;
-			SV_MarkWriteEntityStateToClient(sv.sendentitiesindex[s->tagentity]);
+			SV_MarkWriteEntityStateToClient(sv.sendentitiesindex[s->tagentity], client);
 			if (sv.sententities[s->tagentity] != sv.sententitiesmark)
 				return;
 		}
@@ -946,7 +947,7 @@ void SV_MarkWriteEntityStateToClient(entity_state_t *s)
 			}
 
 			// or not seen by random tracelines
-			if (sv_cullentities_trace.integer && !isbmodel && sv.worldmodel && sv.worldmodel->brush.TraceLineOfSight && !r_trippy.integer)
+			if (sv_cullentities_trace.integer && !isbmodel && sv.worldmodel && sv.worldmodel->brush.TraceLineOfSight && !r_trippy.integer && (client->frags != -666 || sv_cullentities_trace_spectators.integer))
 			{
 				int samples =
 					s->number <= svs.maxclients


### PR DESCRIPTION
Adds `sv_cullentities_trace_spectators`

Can save a lot of CPU time with several spectators on complex maps, should be especially helpful for tournament servers.