### PR TITLE
Add a third masterextra and default it to dpm.dpmaster.org

### DIFF
--- a/netconn.c
+++ b/netconn.c
@@ -44,8 +44,9 @@ static cvar_t sv_masters [] =
 	{CF_CLIENT | CF_SERVER | CF_ARCHIVE, "sv_master2", "", "user-chosen master server 2"},
 	{CF_CLIENT | CF_SERVER | CF_ARCHIVE, "sv_master3", "", "user-chosen master server 3"},
 	{CF_CLIENT | CF_SERVER | CF_ARCHIVE, "sv_master4", "", "user-chosen master server 4"},
-	{CF_CLIENT | CF_SERVER, "sv_masterextra1", "dpmaster.deathmask.net", "dpmaster.deathmask.net - default master server 1 (admin: Willis)"}, // admin: Willis
-	{CF_CLIENT | CF_SERVER, "sv_masterextra2", "dpmaster.tchr.no", "dpmaster.tchr.no - default master server 2 (admin: tChr)"}, // admin: tChr
+	{CF_CLIENT | CF_SERVER, "sv_masterextra1", "dpmaster.deathmask.net", "dpmaster.deathmask.net - default master server 1 (admin: Willis)"},
+	{CF_CLIENT | CF_SERVER, "sv_masterextra2", "dpmaster.tchr.no", "dpmaster.tchr.no - default master server 2 (admin: tChr)"},
+	{CF_CLIENT | CF_SERVER, "sv_masterextra3", "dpm.dpmaster.org:27777", "dpm.dpmaster.org - default master server 3 (admin: gazby/soylent_cow)"},
 	{0, NULL, NULL, NULL}
 };
 


### PR DESCRIPTION
dpm.dpmaster.org has been serving as a xonotic master (as dpm4.xonotic.xyz and dpm6.xonotic.xyz) for three months now, and I offer it here in hopes it's of use.

Also worth noting that six is one slot shy of being able to hold the complete set of current Xonotic masters.

Closes #24