### PR TITLE
Fixed warning on macOS about -fno-signaling-nans

### DIFF
--- a/makefile.inc
+++ b/makefile.inc
@@ -22,7 +22,10 @@ CC?=gcc
 # Experimental
 #CPUOPTIMIZATIONS?=-fno-math-errno -fno-rounding-math -fno-signaling-nans -fassociative-math -freciprocal-math -fno-signed-zeros -fno-trapping-math
 # Normal
-ifeq ($(CC), clang)
+ifneq ($(OS),Windows_NT)
+UNAME_S := $(shell uname -s)
+endif
+ifeq ($(UNAME_S),Darwin)
 	CPUOPTIMIZATIONS?=-fno-math-errno -fno-rounding-math -fno-trapping-math
 else
 	CPUOPTIMIZATIONS?=-fno-math-errno -fno-rounding-math -fno-signaling-nans -fno-trapping-math


### PR DESCRIPTION
This is required to solve the warning about a non-existent flag while compiling on macOS systems.  Searching for 'clang' is not the correct way on macOS due to the fact that clang is disguised as gcc.  While clang exists as clang, clang also exists as gcc and this throws-off the makefile which thinks it is gcc and thus produces the warning about this non-existent flag.

I have wrapped a UNAME in a ifneq Windows_NT so as not to disturb the Windows build and instead of clang, I am using UNAME with Darwin, so as to correctly get the cpu optimisation flags for the system.

There is one catch, FreeBSD also uses clang and this change would not detect that, but I noticed there is no FreeBSD defs in the makefile and so that might not be a huge problem..  considering the size of the user base there.