### PR TITLE
Bring back the curl download status

### DIFF
--- a/cl_screen.c
+++ b/cl_screen.c
@@ -1773,10 +1773,11 @@ static void SCR_DrawScreen (void)
 	if(!scr_loading) {
 		SCR_DrawBrand();
 
-		SCR_DrawInfobar();
-
 		SCR_DrawTouchscreenOverlay();
 	}
+
+	SCR_DrawInfobar();
+
 	if (r_timereport_active)
 		R_TimeReport("2d");
 


### PR DESCRIPTION
Fixes #37.

I don't know if this is the ideal solution, but all I've done is move the InfoBar draw back to unconditional. Things look normal for me with the LoadingScreen before, and after a download, as well as when there is no download, and the curl status now appears as expected.