### PR TITLE
(WIP) changed rendering behavior for Unicode "bigblock" characters

### DIFF
--- a/ft2.h
+++ b/ft2.h
@@ -67,7 +67,7 @@ typedef struct ft2_font_s
 
 void            Font_CloseLibrary(void);
 void            Font_Init(void);
-qbool        Font_OpenLibrary(void);
+qbool           Font_OpenLibrary(void);
 ft2_font_t*     Font_Alloc(void);
 void            Font_UnloadFont(ft2_font_t *font);
 // IndexForSize suggests to change the width and height if a font size is in a reasonable range
@@ -75,11 +75,14 @@ void            Font_UnloadFont(ft2_font_t *font);
 // in such a case, *outw and *outh are set to 12, which is often a good alternative size
 int             Font_IndexForSize(ft2_font_t *font, float size, float *outw, float *outh);
 ft2_font_map_t *Font_MapForIndex(ft2_font_t *font, int index);
-qbool        Font_LoadFont(const char *name, dp_font_t *dpfnt);
-qbool        Font_GetKerningForSize(ft2_font_t *font, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
-qbool        Font_GetKerningForMap(ft2_font_t *font, int map_index, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
+qbool           is_in_bigblock(Uchar ch);
+qbool           Font_LoadFont(const char *name, dp_font_t *dpfnt);
+qbool           Font_GetKerningForSize(ft2_font_t *font, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
+qbool           Font_GetKerningForMap(ft2_font_t *font, int map_index, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
 float           Font_VirtualToRealSize(float sz);
 float           Font_SnapTo(float val, float snapwidth);
 // since this is used on a font_map_t, let's name it FontMap_*
 ft2_font_map_t *FontMap_FindForChar(ft2_font_map_t *start, Uchar ch);
+void FontMap_GetForChar(ft2_font_t *font, int map_index, ft2_font_map_t *start,
+			Uchar ch, ft2_font_map_t **outmap, int *mapch);
 #endif // DP_FREETYPE2_H__

--- a/ft2_fontdefs.h
+++ b/ft2_fontdefs.h
@@ -1,11 +1,21 @@
 #ifndef FT2_PRIVATE_H__
 #define FT2_PRIVATE_H__
 
+#include "draw.h"
+#include "fs.h"
+#include "ft2.h"
+#include "utf8lib.h"
+
 // anything should work, but I recommend multiples of 8
 // since the texture size should be a power of 2
 #define FONT_CHARS_PER_LINE 16
 #define FONT_CHAR_LINES 16
 #define FONT_CHARS_PER_MAP (FONT_CHARS_PER_LINE * FONT_CHAR_LINES)
+
+/* To support higher planes, modify to 0x110000, but that will take more memory
+ * Also see `unicode_bigblocks` in ft2.c
+ */
+#define UNICODE_SIZE 0x10000
 
 typedef struct glyph_slot_s
 {
@@ -35,7 +45,7 @@ struct ft2_font_map_s
 	int                    glyphSize;
 
 	cachepic_t            *pic;
-	qbool               static_tex;
+	qbool                  static_tex;
 	glyph_slot_t           glyphs[FONT_CHARS_PER_MAP];
 
 	// contains the kerning information for the first 256 characters

--- a/gl_draw.c
+++ b/gl_draw.c
@@ -1046,18 +1046,9 @@ float DrawQ_TextWidth_UntilWidth_TrackColors_Scale(const char *text, size_t *max
 			}
 			x += width_of[ch] * dw;
 		} else {
-			if (!map || map == ft2_oldstyle_map || ch < map->start || ch >= map->start + FONT_CHARS_PER_MAP)
-			{
-				map = FontMap_FindForChar(fontmap, ch);
-				if (!map)
-				{
-					if (!Font_LoadMapForIndex(ft2, map_index, ch, &map))
-						break;
-					if (!map)
-						break;
-				}
-			}
-			mapch = ch - map->start;
+			FontMap_GetForChar(ft2, map_index, fontmap, ch, &map, &mapch);
+			if (!map)
+				break;
 			if (prevch && Font_GetKerningForMap(ft2, map_index, w, h, prevch, ch, &kx, NULL))
 				x += kx * dw;
 			x += map->glyphs[mapch].advance_x * dw;
@@ -1259,27 +1250,13 @@ float DrawQ_String_Scale(float startx, float starty, const char *text, size_t ma
 				Mod_Mesh_AddTriangle(mod, surf, e0, e2, e3);
 				x += width_of[ch] * dw;
 			} else {
-				if (!map || map == ft2_oldstyle_map || ch < map->start || ch >= map->start + FONT_CHARS_PER_MAP)
+				FontMap_GetForChar(ft2, map_index, fontmap, ch, &map, &mapch);
+				if (!map)
 				{
-					// find the new map
-					map = FontMap_FindForChar(fontmap, ch);
-					if (!map)
-					{
-						if (!Font_LoadMapForIndex(ft2, map_index, ch, &map))
-						{
-							shadow = -1;
-							break;
-						}
-						if (!map)
-						{
-							// this shouldn't happen
-							shadow = -1;
-							break;
-						}
-					}
+					shadow = -1;
+					break;
 				}
 
-				mapch = ch - map->start;
 				thisw = map->glyphs[mapch].advance_x;
 
 				//x += ftbase_x;


### PR DESCRIPTION
To fix #49, I got the "first move" done, but it's not the end yet, more work needed.

In companion of Xonotic source code, it can be compiled & run...

Some problems are, well, probably out of my scope. Long-time contributors can give advice & feedback!

Thank you!

----

To-do list:

- [x] Basic concepts & routines
- [ ] Maybe something are wrong at the moment. I'm novice to C, please point them out.
- [ ] Get it work to put a char "piece" to existing map ("Incremental"), by updating texture
- [ ] Get the char-/index-to-map mapping done right. Maybe dynamic array allocation to different font face/size
- [ ] Reset the existing mapping when unloading font, to avoid segfaults (e.g. when switching language)
- [ ] Is it right to use a thread mutex to the mappings? (it's there now)
- [ ] Determine that, is it necessary to preserve memory for higher planes in Unicode (`0x10000..0x10FFFF`)?

There are a few `TODO` and `FIXME` around corresponding code, for seeking around.
