### PR TITLE
Fix several long-lasting font rendering problems

### DIFF
--- a/draw.h
+++ b/draw.h
@@ -97,6 +97,7 @@ typedef struct dp_font_s
 {
 	cachepic_t *pic;
 	float width_of[256]; // width_of[0] == max width of any char; 1.0f is base width (1/16 of texture width); therefore, all widths have to be <= 1 (does not include scale)
+	float width_of_ft2[MAX_FONT_SIZES][256];
 	float maxwidth; // precalculated max width of the font (includes scale)
 	char texpath[MAX_QPATH];
 	char title[MAX_QPATH];

--- a/draw.h
+++ b/draw.h
@@ -93,6 +93,7 @@ typedef struct ft2_settings_s
 
 #define MAX_FONT_SIZES 16
 #define MAX_FONT_FALLBACKS 3
+#define MAX_FONT_CMDLINE MAX_QPATH * (MAX_FONT_FALLBACKS + 1)
 typedef struct dp_font_s
 {
 	cachepic_t *pic;
@@ -109,6 +110,8 @@ typedef struct dp_font_s
 	struct ft2_font_s *ft2;
 
 	ft2_settings_t settings;
+
+	char cmdline[MAX_FONT_CMDLINE];
 }
 dp_font_t;
 

--- a/ft2.c
+++ b/ft2.c
@@ -32,11 +32,11 @@ static int img_fontmap[256] = {
  *     http://www.unicode.org/Public/UNIDATA/Blocks.txt
  *
  * Let's call these "bigblocks".
- * These appears in a text in a "spreaded" way, ordinary maps will 
+ * These characters are "spreaded", and ordinary maps will 
  *     waste huge amount of resources rendering/caching unused glyphs.
  *
- * So, another matter is invented to counter this: incremental maps,
- *     in which only used glyphs may present.
+ * So, a new design is introduced to solve the problem:
+ *     incremental maps, in which only used glyphs are stored.
  */
 static const Uchar unicode_bigblocks[] = {
 	0x3400, 0x4DBF, 	//   6592  CJK Unified Ideographs Extension A
@@ -53,7 +53,7 @@ CVars introduced with the freetype extension
 */
 
 cvar_t r_font_disable_freetype = {CF_CLIENT | CF_ARCHIVE, "r_font_disable_freetype", "0", "disable freetype support for fonts entirely"};
-cvar_t r_font_use_alpha_textures = {CF_CLIENT | CF_ARCHIVE, "r_font_use_alpha_textures", "0", "[deprecated, not effective] use alpha-textures for font rendering, this should safe memory"};
+cvar_t r_font_use_alpha_textures = {CF_CLIENT | CF_ARCHIVE, "r_font_use_alpha_textures", "0", "[deprecated, not effective] use alpha-textures for font rendering, this should save memory"};
 cvar_t r_font_size_snapping = {CF_CLIENT | CF_ARCHIVE, "r_font_size_snapping", "1", "stick to good looking font sizes whenever possible - bad when the mod doesn't support it!"};
 cvar_t r_font_kerning = {CF_CLIENT | CF_ARCHIVE, "r_font_kerning", "1", "Use kerning if available"};
 cvar_t r_font_diskcache = {CF_CLIENT | CF_ARCHIVE, "r_font_diskcache", "0", "[deprecated, not effective] save font textures to disk for future loading rather than generating them every time"};
@@ -1505,7 +1505,7 @@ static qbool Font_LoadMap(ft2_font_t *font, ft2_font_map_t *mapstart, Uchar _ch,
 	map = (ft2_font_map_t *)Mem_Alloc(font_mempool, sizeof(ft2_font_map_t));
 	if (!map)
 	{
-		Con_Printf(CON_ERROR "ERROR: Out of memory when allowcating fontmap for %s\n", font->name);
+		Con_Printf(CON_ERROR "ERROR: Out of memory when allocating fontmap for %s\n", font->name);
 		return false;
 	}
 
@@ -1571,7 +1571,7 @@ static qbool Font_LoadMap(ft2_font_t *font, ft2_font_map_t *mapstart, Uchar _ch,
 			incmap = mapstart->incmap = (font_incmap_t *)Mem_Alloc(font_mempool, sizeof(font_incmap_t));
 			if (!incmap)
 			{
-				Con_Printf(CON_ERROR "ERROR: Out of memory when allowcating incremental fontmap for %s\n", font->name);
+				Con_Printf(CON_ERROR "ERROR: Out of memory when allocating incremental fontmap for %s\n", font->name);
 				return false;
 			}
 			// this will be the startmap of incmap

--- a/ft2.h
+++ b/ft2.h
@@ -21,6 +21,8 @@
  */
 
 typedef struct ft2_font_map_s ft2_font_map_t;
+typedef struct font_incmap_s font_incmap_t;
+typedef struct incmap_lookup_cache_s incmap_lookup_cache_t;
 typedef struct ft2_attachment_s ft2_attachment_t;
 #ifdef WIN64
 #define ft2_oldstyle_map ((ft2_font_map_t*)-1LL)
@@ -36,38 +38,38 @@ typedef struct ft2_kerning_s
 
 typedef struct ft2_font_s
 {
-	char            name[64];
-	qbool        has_kerning;
+	char   name[64];
+	qbool  has_kerning;
 	// last requested size loaded using Font_SetSize
-	float		currentw;
-	float		currenth;
-	float           ascend;
-	float           descend;
-	qbool        image_font; // only fallbacks are freetype fonts
+	float  currentw;
+	float  currenth;
+	float  ascend;
+	float  descend;
+	qbool  image_font; // only fallbacks are freetype fonts
 
 	// TODO: clean this up and do not expose everything.
-	
+
 	const unsigned char  *data; // FT2 needs it to stay
 	//fs_offset_t     datasize;
-	void           *face;
+	void                 *face;
 
 	// an unordered array of ordered linked lists of glyph maps for a specific size
-	ft2_font_map_t *font_maps[MAX_FONT_SIZES];
-	int             num_sizes;
+	ft2_font_map_t       *font_maps[MAX_FONT_SIZES];
+	int                   num_sizes;
 
 	// attachments
-	size_t            attachmentcount;
-	ft2_attachment_t *attachments;
+	size_t                attachmentcount;
+	ft2_attachment_t     *attachments;
 
-	ft2_settings_t *settings;
+	ft2_settings_t       *settings;
 
 	// fallback mechanism
-	struct ft2_font_s *next;
+	struct ft2_font_s    *next;
 } ft2_font_t;
 
 void            Font_CloseLibrary(void);
 void            Font_Init(void);
-qbool        Font_OpenLibrary(void);
+qbool           Font_OpenLibrary(void);
 ft2_font_t*     Font_Alloc(void);
 void            Font_UnloadFont(ft2_font_t *font);
 // IndexForSize suggests to change the width and height if a font size is in a reasonable range
@@ -75,11 +77,12 @@ void            Font_UnloadFont(ft2_font_t *font);
 // in such a case, *outw and *outh are set to 12, which is often a good alternative size
 int             Font_IndexForSize(ft2_font_t *font, float size, float *outw, float *outh);
 ft2_font_map_t *Font_MapForIndex(ft2_font_t *font, int index);
-qbool        Font_LoadFont(const char *name, dp_font_t *dpfnt);
-qbool        Font_GetKerningForSize(ft2_font_t *font, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
-qbool        Font_GetKerningForMap(ft2_font_t *font, int map_index, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
+qbool           Font_LoadFont(const char *name, dp_font_t *dpfnt);
+qbool           Font_GetKerningForSize(ft2_font_t *font, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
+qbool           Font_GetKerningForMap(ft2_font_t *font, int map_index, float w, float h, Uchar left, Uchar right, float *outx, float *outy);
 float           Font_VirtualToRealSize(float sz);
 float           Font_SnapTo(float val, float snapwidth);
 // since this is used on a font_map_t, let's name it FontMap_*
 ft2_font_map_t *FontMap_FindForChar(ft2_font_map_t *start, Uchar ch);
+qbool           Font_GetMapForChar(ft2_font_t *font, int map_index, Uchar ch, ft2_font_map_t **outmap, int *outmapch);
 #endif // DP_FREETYPE2_H__

--- a/ft2_fontdefs.h
+++ b/ft2_fontdefs.h
@@ -7,6 +7,9 @@
 #define FONT_CHAR_LINES 16
 #define FONT_CHARS_PER_MAP (FONT_CHARS_PER_LINE * FONT_CHAR_LINES)
 
+// map.start value for incremental maps to hold a place
+#define INCMAP_START 0x110000
+
 typedef struct glyph_slot_s
 {
 	qbool image;
@@ -26,32 +29,55 @@ typedef struct glyph_slot_s
 
 struct ft2_font_map_s
 {
-	Uchar                  start;
-	struct ft2_font_map_s *next;
-	float                  size;
+	Uchar  start;
+	float  size;
+
 	// the actual size used in the freetype code
 	// by convention, the requested size is the height of the font's bounding box.
-	float                  intSize;
-	int                    glyphSize;
+	float  intSize;
+	int    glyphSize;
 
-	cachepic_t            *pic;
-	qbool               static_tex;
-	glyph_slot_t           glyphs[FONT_CHARS_PER_MAP];
+	ft2_font_map_t *next;
+	cachepic_t     *pic;
+	qbool           static_tex;
+	glyph_slot_t    glyphs[FONT_CHARS_PER_MAP];
+	Uchar           glyphchars[FONT_CHARS_PER_MAP];
 
+	// safes us the trouble of calculating these over and over again
+	double          sfx, sfy;
+
+	// note: float width_of[256] was moved to `struct dp_font_s` as width_of_ft2
+
+	// these may only present in a startmap
 	// contains the kerning information for the first 256 characters
 	// for the other characters, we will lookup the kerning information
-	ft2_kerning_t          kerning;
-	// safes us the trouble of calculating these over and over again
-	double                 sfx, sfy;
+	ft2_kerning_t  *kerning;
+	// for accessing incremental maps for bigblock glyphs
+	font_incmap_t  *incmap;
+};
 
-	// the width_of for the image-font, pixel-snapped for this size
-	float           width_of[256];
+struct font_incmap_s
+{
+	// associated fontmap; startmap of incmaps
+	struct ft2_font_map_s *fontmap;
+	int charcount;
+	int newmap_start;
+
+	// two rounds of merge will take place, keep those data until then
+	unsigned char *data_tier1[FONT_CHARS_PER_LINE];
+	unsigned char *data_tier2[FONT_CHAR_LINES];
+
+	// count of merged maps
+	int tier1_merged, tier2_merged;
+
+	// in case it changed middleway, convert previous data
+	int bytes_per_pixel;
 };
 
 struct ft2_attachment_s
 {
 	const unsigned char *data;
-	fs_offset_t    size;
+	fs_offset_t          size;
 };
 
 //qbool Font_LoadMapForIndex(ft2_font_t *font, Uchar _ch, ft2_font_map_t **outmap);

--- a/ft2_fontdefs.h
+++ b/ft2_fontdefs.h
@@ -43,7 +43,7 @@ struct ft2_font_map_s
 	glyph_slot_t    glyphs[FONT_CHARS_PER_MAP];
 	Uchar           glyphchars[FONT_CHARS_PER_MAP];
 
-	// safes us the trouble of calculating these over and over again
+	// saves us the trouble of calculating these over and over again
 	double          sfx, sfy;
 
 	// note: float width_of[256] was moved to `struct dp_font_s` as width_of_ft2

--- a/ft2_fontdefs.h
+++ b/ft2_fontdefs.h
@@ -69,9 +69,6 @@ struct font_incmap_s
 
 	// count of merged maps
 	int tier1_merged, tier2_merged;
-
-	// in case it changed middleway, convert previous data
-	int bytes_per_pixel;
 };
 
 struct ft2_attachment_s

--- a/gl_draw.c
+++ b/gl_draw.c
@@ -927,7 +927,6 @@ float DrawQ_TextWidth_UntilWidth_TrackColors_Scale(const char *text, size_t *max
 	size_t bytes_left;
 	ft2_font_map_t *fontmap = NULL;
 	ft2_font_map_t *map = NULL;
-	//ft2_font_map_t *prevmap = NULL;
 	ft2_font_t *ft2 = fnt->ft2;
 	// float ftbase_x;
 	qbool snap = true;
@@ -994,11 +993,11 @@ float DrawQ_TextWidth_UntilWidth_TrackColors_Scale(const char *text, size_t *max
 		if (ch == ' ' && !fontmap)
 		{
 			if(!least_one || i0) // never skip the first character
-			if(x + width_of[(int) ' '] * dw > maxwidth)
-			{
-				i = i0;
-				break; // oops, can't draw this
-			}
+				if(x + width_of[(int) ' '] * dw > maxwidth)
+				{
+					i = i0;
+					break; // oops, can't draw this
+				}
 			x += width_of[(int) ' '] * dw;
 			continue;
 		}
@@ -1043,11 +1042,11 @@ float DrawQ_TextWidth_UntilWidth_TrackColors_Scale(const char *text, size_t *max
 				map = ft2_oldstyle_map;
 			prevch = 0;
 			if(!least_one || i0) // never skip the first character
-			if(x + width_of[ch] * dw > maxwidth)
-			{
-				i = i0;
-				break; // oops, can't draw this
-			}
+				if(x + width_of[ch] * dw > maxwidth)
+				{
+					i = i0;
+					break; // oops, can't draw this
+				}
 			x += width_of[ch] * dw;
 		} else {
 			if (!map || map == ft2_oldstyle_map || ch != prevch)
@@ -1059,7 +1058,6 @@ float DrawQ_TextWidth_UntilWidth_TrackColors_Scale(const char *text, size_t *max
 			if (prevch && Font_GetKerningForMap(ft2, map_index, w, h, prevch, ch, &kx, NULL))
 				x += kx * dw;
 			x += map->glyphs[mapch].advance_x * dw;
-			//prevmap = map;
 			prevch = ch;
 		}
 	}
@@ -1081,7 +1079,6 @@ float DrawQ_String_Scale(float startx, float starty, const char *text, size_t ma
 	Uchar ch, mapch, nextch;
 	Uchar prevch = 0; // used for kerning
 	int map_index = 0;
-	//ft2_font_map_t *prevmap = NULL; // the previous map
 	ft2_font_map_t *map = NULL;     // the currently used map
 	ft2_font_map_t *fontmap = NULL; // the font map for the size
 	float ftbase_y;

--- a/gl_draw.c
+++ b/gl_draw.c
@@ -354,17 +354,13 @@ void LoadFont(qbool override, const char *name, dp_font_t *fnt, float scale, flo
 	if(drawtexturepool == NULL)
 		return; // before gl_draw_start, so will be loaded later
 
-	/*
-	// this "reset" seems interrupts fontmap loading and wastes previous works
-	// no side-effects so far without this
 	if(fnt->ft2)
 	{
-		// clear freetype font
+		// clear previous freetype font to prevent leaking memory
 		Font_UnloadFont(fnt->ft2);
 		Mem_Free(fnt->ft2);
 		fnt->ft2 = NULL;
 	}
-	*/
 
 	if(fnt->req_face != -1)
 	{


### PR DESCRIPTION
This patch is effort of half one year and more than 3 trials by 2 persons.

Several big problems in font rendering (`ft2`) were solved. Read more below.

Before merging, it is wise to look into the [code](https://github.com/NaitLee/darkplaces/tree/NaitLee/ft2-better-maps-for-bigblock-chars) and [give it some test](https://github.com/NaitLee/darkplaces/releases/tag/patch-snapshot-0) first.

----

**Patch summary:**

- Fix the overall problem stated in #49 with the idea “incremental maps”
  - New API `Font_GetMapForChar` for better support, mostly because `mapch` can be dynamic; `FontMap_FindForChar` and `Font_LoadMapForIndex` become legacy, but still can be used (without `incmap` support, behaves as usual)
  - The new CVar `r_font_disable_incmaps` for always using old mapping behavior, useful for e.g. comparing the before/after of this fix
- Fix the problem stated in #65
  - `float kerning[256][256]` in `struct ft2_font_map_s` is now `*float[256][256]`, and only allocated & assigned in a `startmap`
  - `width_of[256]` in `struct ft2_font_map_s` is moved to `struct dp_font_s` `width_of_ft2[MAX_FONT_SIZES][256]`
  - Code relative to these are modified accordingly
- Deprecate `r_font_diskcache` as stated in #66

----

**Git log:**

Fix resources waste of fontmap usage worst-cases;
Fix memory waste of improperly designed `struct ft2_font_map_s`; Deprecate `r_font_diskcache`

Signed-off-by: NaitLee <naitli@foxmail.com>