### PR TITLE
Fixed two keyboard bugs

### DIFF
--- a/keys.c
+++ b/keys.c
@@ -1351,6 +1351,7 @@ the K_* names are matched up.
 int
 Key_StringToKeynum (const char *str)
 {
+	Uchar ch;
 	const keyname_t  *kn;
 
 	if (!str || !str[0])
@@ -1362,7 +1363,10 @@ Key_StringToKeynum (const char *str)
 		if (!strcasecmp (str, kn->name))
 			return kn->keynum;
 	}
-	return -1;
+
+	// non-ascii keys are Unicode codepoints, so give the character
+	ch = u8_getnchar(str, &str, 3);
+	return ch == 0 ? -1 : (int)ch;
 }
 
 /*
@@ -1387,13 +1391,9 @@ Key_KeynumToString (int keynum, char *tinystr, size_t tinystrlength)
 			return kn->name;
 
 	// if it is printable, output it as a single character
-	if (keynum > 32 && keynum < 256)
+	if (keynum > 32)
 	{
-		if (tinystrlength >= 2)
-		{
-			tinystr[0] = keynum;
-			tinystr[1] = 0;
-		}
+		u8_fromchar(keynum, tinystr, tinystrlength);
 		return tinystr;
 	}
 
@@ -1586,7 +1586,7 @@ static void
 Key_PrintBindList(int j)
 {
 	char bindbuf[MAX_INPUTLINE];
-	char tinystr[2];
+	char tinystr[TINYSTR_LEN];
 	const char *p;
 	int i;
 
@@ -1679,7 +1679,7 @@ Key_WriteBindings (qfile_t *f)
 {
 	int         i, j;
 	char bindbuf[MAX_INPUTLINE];
-	char tinystr[2];
+	char tinystr[TINYSTR_LEN];
 	const char *p;
 
 	// Override default binds

--- a/keys.c
+++ b/keys.c
@@ -1364,9 +1364,10 @@ Key_StringToKeynum (const char *str)
 			return kn->keynum;
 	}
 
-	// non-ascii keys are Unicode codepoints, so give the character
+	// non-ascii keys are Unicode codepoints, so give the character if it's valid;
+	// error message have more than one character, don't allow it
 	ch = u8_getnchar(str, &str, 3);
-	return ch == 0 ? -1 : (int)ch;
+	return (ch == 0 || *str != 0) ? -1 : (int)ch;
 }
 
 /*
@@ -1597,9 +1598,9 @@ Key_PrintBindList(int j)
 		{
 			Cmd_QuoteString(bindbuf, sizeof(bindbuf), p, "\"\\", false);
 			if (j == 0)
-				Con_Printf("^2%s ^7= \"%s\"\n", Key_KeynumToString (i, tinystr, sizeof(tinystr)), bindbuf);
+				Con_Printf("^2%s ^7= \"%s\"\n", Key_KeynumToString (i, tinystr, TINYSTR_LEN), bindbuf);
 			else
-				Con_Printf("^3bindmap %d: ^2%s ^7= \"%s\"\n", j, Key_KeynumToString (i, tinystr, sizeof(tinystr)), bindbuf);
+				Con_Printf("^3bindmap %d: ^2%s ^7= \"%s\"\n", j, Key_KeynumToString (i, tinystr, TINYSTR_LEN), bindbuf);
 		}
 	}
 }
@@ -1694,9 +1695,9 @@ Key_WriteBindings (qfile_t *f)
 			{
 				Cmd_QuoteString(bindbuf, sizeof(bindbuf), p, "\"\\", false); // don't need to escape $ because cvars are not expanded inside bind
 				if (j == 0)
-					FS_Printf(f, "bind %s \"%s\"\n", Key_KeynumToString (i, tinystr, sizeof(tinystr)), bindbuf);
+					FS_Printf(f, "bind %s \"%s\"\n", Key_KeynumToString (i, tinystr, TINYSTR_LEN), bindbuf);
 				else
-					FS_Printf(f, "in_bind %d %s \"%s\"\n", j, Key_KeynumToString (i, tinystr, sizeof(tinystr)), bindbuf);
+					FS_Printf(f, "in_bind %d %s \"%s\"\n", j, Key_KeynumToString (i, tinystr, TINYSTR_LEN), bindbuf);
 			}
 		}
 	}

--- a/keys.h
+++ b/keys.h
@@ -33,6 +33,16 @@
 #include "fs.h"
 #include "cmd.h"
 
+// the highest Unicode character to allow key binding.
+// note that an excessively high value may degrade fps
+// when code is looping through the bindings
+#define MAX_KEY_BINDS 0xfff0
+
+// how long is a "tinystr" to hold a keyboard key's
+// Unicode utf-8 presentation, plus final \x00
+// to allow all characters <= 0xffff, use 4
+#define TINYSTR_LEN 4
+
 //
 // these are the key numbers that should be passed to Key_Event
 //
@@ -353,7 +363,7 @@ typedef enum keynum_e
 	K_MIDINOTE126,
 	K_MIDINOTE127,
 
-	MAX_KEYS
+	MAX_KEYS = MAX_KEY_BINDS
 }
 keynum_t;
 

--- a/menu.c
+++ b/menu.c
@@ -2643,7 +2643,7 @@ static void M_Keys_Draw (void)
 			strlcpy(keystring, "???", sizeof(keystring));
 		else
 		{
-			char tinystr[2];
+			char tinystr[TINYSTR_LEN];
 			keystring[0] = 0;
 			for (j = 0;j < NUMKEYS;j++)
 			{
@@ -2669,7 +2669,7 @@ static void M_Keys_Key(cmd_state_t *cmd, int k, int ascii)
 {
 	char	line[80];
 	int		keys[NUMKEYS];
-	char	tinystr[2];
+	char	tinystr[TINYSTR_LEN];
 
 	if (bind_grab)
 	{	// defining a key

--- a/menu.c
+++ b/menu.c
@@ -2651,7 +2651,7 @@ static void M_Keys_Draw (void)
 				{
 					if (j > 0)
 						strlcat(keystring, " or ", sizeof(keystring));
-					strlcat(keystring, Key_KeynumToString (keys[j], tinystr, sizeof(tinystr)), sizeof(keystring));
+					strlcat(keystring, Key_KeynumToString (keys[j], tinystr, TINYSTR_LEN), sizeof(keystring));
 				}
 			}
 		}
@@ -2680,7 +2680,7 @@ static void M_Keys_Key(cmd_state_t *cmd, int k, int ascii)
 		}
 		else //if (k != '`')
 		{
-			dpsnprintf(line, sizeof(line), "bind \"%s\" \"%s\"\n", Key_KeynumToString(k, tinystr, sizeof(tinystr)), bindnames[keys_cursor][0]);
+			dpsnprintf(line, sizeof(line), "bind \"%s\" \"%s\"\n", Key_KeynumToString(k, tinystr, TINYSTR_LEN), bindnames[keys_cursor][0]);
 			Cbuf_InsertText (cmd, line);
 		}
 

--- a/prvm_cmds.c
+++ b/prvm_cmds.c
@@ -3268,7 +3268,7 @@ string keynumtostring(float keynum)
 */
 void VM_keynumtostring (prvm_prog_t *prog)
 {
-	char tinystr[2];
+	char tinystr[TINYSTR_LEN];
 	VM_SAFEPARMCOUNT(1, VM_keynumtostring);
 
 	PRVM_G_INT(OFS_RETURN) = PRVM_SetTempString(prog, Key_KeynumToString((int)PRVM_G_FLOAT(OFS_PARM0), tinystr, sizeof(tinystr)));

--- a/prvm_cmds.c
+++ b/prvm_cmds.c
@@ -3271,7 +3271,7 @@ void VM_keynumtostring (prvm_prog_t *prog)
 	char tinystr[TINYSTR_LEN];
 	VM_SAFEPARMCOUNT(1, VM_keynumtostring);
 
-	PRVM_G_INT(OFS_RETURN) = PRVM_SetTempString(prog, Key_KeynumToString((int)PRVM_G_FLOAT(OFS_PARM0), tinystr, sizeof(tinystr)));
+	PRVM_G_INT(OFS_RETURN) = PRVM_SetTempString(prog, Key_KeynumToString((int)PRVM_G_FLOAT(OFS_PARM0), tinystr, TINYSTR_LEN));
 }
 
 /*

--- a/vid_sdl.c
+++ b/vid_sdl.c
@@ -100,7 +100,8 @@ static int MapKey( unsigned int sdlkey )
 {
 	switch(sdlkey)
 	{
-	default: return 0;
+	// sdlkey can be Unicode codepoint for non-ascii keys, which are valid
+	default:                      return sdlkey;
 //	case SDLK_UNKNOWN:            return K_UNKNOWN;
 	case SDLK_RETURN:             return K_ENTER;
 	case SDLK_ESCAPE:             return K_ESCAPE;
@@ -1066,6 +1067,7 @@ void Sys_SendKeyEvents( void )
 	static qbool sound_active = true;
 	int keycode;
 	int i;
+	const char *chp;
 	qbool isdown;
 	Uchar unicode;
 	SDL_Event event;
@@ -1222,9 +1224,14 @@ void Sys_SendKeyEvents( void )
 #endif
 				// convert utf8 string to char
 				// NOTE: this code is supposed to run even if utf8enable is 0
-				unicode = u8_getchar_utf8_enabled(event.text.text + (int)u8_bytelen(event.text.text, 0), NULL);
-				Key_Event(K_TEXT, unicode, true);
-				Key_Event(K_TEXT, unicode, false);
+				chp = event.text.text;
+				while (*chp != 0)
+				{
+					// input the chars one by one (there can be multiple chars when e.g. using an "input method")
+					unicode = u8_getchar_utf8_enabled(chp, &chp);
+					Key_Event(K_TEXT, unicode, true);
+					Key_Event(K_TEXT, unicode, false);
+				}
 				break;
 			case SDL_MOUSEMOTION:
 				break;

--- a/vid_sdl.c
+++ b/vid_sdl.c
@@ -101,7 +101,7 @@ static int MapKey( unsigned int sdlkey )
 	switch(sdlkey)
 	{
 	// sdlkey can be Unicode codepoint for non-ascii keys, which are valid
-	default:                      return sdlkey;
+	default:                      return sdlkey & SDLK_SCANCODE_MASK ? 0 : sdlkey;
 //	case SDLK_UNKNOWN:            return K_UNKNOWN;
 	case SDLK_RETURN:             return K_ENTER;
 	case SDLK_ESCAPE:             return K_ESCAPE;


### PR DESCRIPTION
Fixed inability to bind non-ascii keys, so that players can use their native keyboard layout for both chatting and fragging.
([See issues like this](https://gitlab.com/xonotic/darkplaces/-/issues/46))

Fixed only the first character being input when using an Input Method (Asian languages practice)

Signed-off-by: NaitLee <naitli@foxmail.com>