### PR TITLE
Apply default lightstyle to to lightmap when using q3bsp

### DIFF
--- a/gl_rmain.c
+++ b/gl_rmain.c
@@ -5489,6 +5489,11 @@ void R_UpdateVariables(void)
 	if (r_refdef.scene.worldmodel)
 	{
 		r_refdef.scene.lightmapintensity *= r_refdef.scene.worldmodel->lightmapscale;
+
+		// Apply the default lightstyle to the lightmap even on q3bsp
+		if (cl.worldmodel && cl.worldmodel->type == mod_brushq3) {
+			r_refdef.scene.lightmapintensity *= r_refdef.scene.rtlightstylevalue[0];
+		}
 	}
 	if (r_showsurfaces.integer)
 	{


### PR DESCRIPTION
Fixes #100 

Applies Baker's fix so that lightstyle 0 properly affects the default lightmap when using q3bsp.