### PR TITLE
Fix r_glsl_dumpshader segfault

### DIFF
--- a/gl_rmain.c
+++ b/gl_rmain.c
@@ -1418,7 +1418,8 @@ void R_GLSL_Restart_f(cmd_state_t *cmd)
 
 static void R_GLSL_DumpShader_f(cmd_state_t *cmd)
 {
-	unsigned i, language, mode, dupe;
+	unsigned i;
+	int language, mode, dupe;
 	char *text;
 	shadermodeinfo_t *modeinfo;
 	qfile_t *file;


### PR DESCRIPTION
Fixed #145 by changing `dupe` variable back from `unsigned int` to `int`.