### PR TITLE
Print centerprint messages to the console

### DIFF
--- a/cl_screen.c
+++ b/cl_screen.c
@@ -142,7 +142,10 @@ for a few moments
 */
 void SCR_CenterPrint(const char *str)
 {
-	Con_CenterPrint(str);
+	// Print the message to the console, but only if it's different to the previous message
+	if (strcmp(str, scr_centerstring))
+		Con_CenterPrint(str);
+
 	dp_strlcpy(scr_centerstring, str, sizeof (scr_centerstring));
 	scr_centertime_off = scr_centertime.value;
 	scr_centertime_start = cl.time;

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -142,6 +142,9 @@ for a few moments
 */
 void SCR_CenterPrint(const char *str)
 {
+	if (str[0] == '\0') // happens when stepping out of a centreprint trigger on alk1.2 start.bsp
+		return;
+
 	// Print the message to the console, but only if it's different to the previous message
 	if (strcmp(str, scr_centerstring))
 		Con_CenterPrint(str);

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -144,11 +144,9 @@ void SCR_CenterPrint(const char *str)
 {
 	// Print the message to the console, but only if it's different to the previous message
 	if (strcmp(str, scr_centerstring))
-	{
 		Con_CenterPrint(str);
-	}
+	dp_strlcpy(scr_centerstring, str, sizeof(scr_centerstring));
 
-	dp_strlcpy(scr_centerstring, str, sizeof (scr_centerstring));
 	scr_centertime_off = scr_centertime.value;
 	scr_centertime_start = cl.time;
 
@@ -173,6 +171,7 @@ static void SCR_Centerprint_f (cmd_state_t *cmd)
 {
 	char msg[MAX_INPUTLINE];
 	unsigned int i, c, p;
+
 	c = Cmd_Argc(cmd);
 	if(c >= 2)
 	{

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -146,7 +146,7 @@ void SCR_CenterPrint(const char *str)
 	if (strcmp(str, scr_centerstring))
 	{
 		Con_MaskPrint(CON_MASK_HIDENOTIFY, "\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
-		Con_MaskPrint(CON_MASK_HIDENOTIFY, msg);
+		Con_MaskPrint(CON_MASK_HIDENOTIFY, str);
 		Con_MaskPrint(CON_MASK_HIDENOTIFY, "\n\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
 	}
 

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -145,9 +145,7 @@ void SCR_CenterPrint(const char *str)
 	// Print the message to the console, but only if it's different to the previous message
 	if (strcmp(str, scr_centerstring))
 	{
-		Con_MaskPrint(CON_MASK_HIDENOTIFY, "\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
-		Con_MaskPrint(CON_MASK_HIDENOTIFY, str);
-		Con_MaskPrint(CON_MASK_HIDENOTIFY, "\n\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
+		Con_CenterPrint(str);
 	}
 
 	dp_strlcpy(scr_centerstring, str, sizeof (scr_centerstring));
@@ -178,12 +176,14 @@ static void SCR_Centerprint_f (cmd_state_t *cmd)
 	c = Cmd_Argc(cmd);
 	if(c >= 2)
 	{
+		// Merge all the cprint arguments into one string
 		dp_strlcpy(msg, Cmd_Argv(cmd,1), sizeof(msg));
 		for(i = 2; i < c; ++i)
 		{
 			dp_strlcat(msg, " ", sizeof(msg));
 			dp_strlcat(msg, Cmd_Argv(cmd, i), sizeof(msg));
 		}
+
 		c = (unsigned int)strlen(msg);
 		for(p = 0, i = 0; i < c; ++i)
 		{

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -142,7 +142,8 @@ for a few moments
 */
 void SCR_CenterPrint(const char *str)
 {
-	dp_strlcpy (scr_centerstring, str, sizeof (scr_centerstring));
+	Con_CenterPrint(str);
+	dp_strlcpy(scr_centerstring, str, sizeof (scr_centerstring));
 	scr_centertime_off = scr_centertime.value;
 	scr_centertime_start = cl.time;
 

--- a/cl_screen.c
+++ b/cl_screen.c
@@ -144,7 +144,11 @@ void SCR_CenterPrint(const char *str)
 {
 	// Print the message to the console, but only if it's different to the previous message
 	if (strcmp(str, scr_centerstring))
-		Con_CenterPrint(str);
+	{
+		Con_MaskPrint(CON_MASK_HIDENOTIFY, "\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
+		Con_MaskPrint(CON_MASK_HIDENOTIFY, msg);
+		Con_MaskPrint(CON_MASK_HIDENOTIFY, "\n\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
+	}
 
 	dp_strlcpy(scr_centerstring, str, sizeof (scr_centerstring));
 	scr_centertime_off = scr_centertime.value;

--- a/console.c
+++ b/console.c
@@ -107,8 +107,6 @@ int rcon_redirect_bufferpos = 0;
 char rcon_redirect_buffer[1400];
 qbool rcon_redirect_proquakeprotocol = false;
 
-char con_previouscenterprint[1024];
-
 // generic functions for console buffers
 
 void ConBuffer_Init(conbuffer_t *buf, int textsize, int maxlines, mempool_t *mempool)

--- a/console.c
+++ b/console.c
@@ -1513,17 +1513,15 @@ void Con_DPrintf(const char *fmt, ...)
  *
  * @return     A string of the line
  */
-const char *Con_Quakebar(int len)
+const char *Con_Quakebar(int len, char *bar, size_t barsize)
 {
-	static char bar[42];
-	int         i;
+	assert(barsize >= 5);
 
-	len = min(len, (int)sizeof(bar) - 2);
+	len = min(len, (int)barsize - 2);
 	len = min(len, con_linewidth);
 
 	bar[0] = '\35';
-	for (i = 1; i < len - 1; i++)
-		bar[i] = '\36';
+	memset(&bar[1], '\36', len - 2);
 	bar[len - 1] = '\37';
 
 	if (len < con_linewidth)
@@ -1599,9 +1597,11 @@ void Con_CenterPrintf(int maxLineLength, const char *fmt, ...)
  */
 void Con_CenterPrint(const char *str)
 {
-	Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s", Con_Quakebar(40));
+	char bar[42];
+
+	Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s", Con_Quakebar(40, bar, sizeof(bar)));
 	Con_CenterPrintf(40, "%s\n", str);
-	Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s", Con_Quakebar(40));
+	Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s", bar);
 }
 
 

--- a/console.c
+++ b/console.c
@@ -107,6 +107,8 @@ int rcon_redirect_bufferpos = 0;
 char rcon_redirect_buffer[1400];
 qbool rcon_redirect_proquakeprotocol = false;
 
+char con_previouscenterprint[1024];
+
 // generic functions for console buffers
 
 void ConBuffer_Init(conbuffer_t *buf, int textsize, int maxlines, mempool_t *mempool)
@@ -1500,6 +1502,19 @@ void Con_DPrintf(const char *fmt, ...)
 	va_end(argptr);
 
 	Con_MaskPrint(CON_MASK_DEVELOPER, msg);
+}
+
+/*
+================
+Con_CenterPrint
+================
+*/
+void Con_CenterPrint(const char *msg)
+{
+	if (strcmp(msg, con_previouscenterprint))
+		return;
+
+	Con_Print(msg);
 }
 
 

--- a/console.c
+++ b/console.c
@@ -1503,6 +1503,104 @@ void Con_DPrintf(const char *fmt, ...)
 }
 
 
+
+/**
+ * @brief      Returns a horizontal line
+ * @details    Returns a graphical horizontal line of length len, but never wider than the
+ *             console. Includes a newline, unless len is >= to the console width
+ * @note       Authored by johnfitz
+ *
+ * @param[in]  len   Length of the horizontal line
+ *
+ * @return     A string of the line
+ */
+const char *Con_Quakebar(int len)
+{
+	static char bar[42];
+	int         i;
+
+	len = min(len, (int)sizeof(bar) - 2);
+	len = min(len, con_linewidth);
+
+	bar[0] = '\35';
+	for (i = 1; i < len - 1; i++)
+		bar[i] = '\36';
+	bar[len - 1] = '\37';
+
+	if (len < con_linewidth)
+	{
+		bar[len] = '\n';
+		bar[len + 1] = 0;
+	}
+	else
+		bar[len] = 0;
+
+	return bar;
+}
+
+
+
+/**
+ * @brief      Left-pad a string with spaces to make it appear centered
+ * @note       Authored by johnfitz
+ *
+ * @param[in]  linewidth  The linewidth
+ * @param[in]  fmt        A printf format string
+ * @param[in]  <unnamed>  One or more variables required in fmt
+ */
+void Con_CenterPrintf(int linewidth, const char *fmt, ...)
+{
+	va_list argptr;
+	char	msg[MAX_INPUTLINE];  // the original message
+	char	line[MAX_INPUTLINE]; // one line from the message
+	char	spaces[21];		     // buffer for spaces
+	char   *src, *dst;
+	int		len, s;
+
+	va_start(argptr, fmt);
+	dpvsnprintf(msg, sizeof (msg), fmt, argptr);
+	va_end(argptr);
+
+	linewidth = min(linewidth, con_linewidth);
+	for (src = msg; *src;)
+	{
+		dst = line;
+		while (*src && *src != '\n')
+			*dst++ = *src++;
+		*dst = 0;
+		if (*src == '\n')
+			src++;
+
+		len = strlen(line);
+		if (len < linewidth)
+		{
+			s = (linewidth - len) / 2;
+			memset(spaces, ' ', s);
+			spaces[s] = 0;
+			Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s%s\n", spaces, line);
+		}
+		else
+			Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s\n", line);
+	}
+}
+
+
+
+/**
+ * @brief      Prints a center-aligned message to the console
+ * @note       Authored by johnfitz
+ *
+ * @param[in]  str   A multiline string to print
+ */
+void Con_CenterPrint(const char *str)
+{
+	Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s", Con_Quakebar(40));
+	Con_CenterPrintf(40, "%s\n", str);
+	Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s", Con_Quakebar(40));
+}
+
+
+
 /*
 ==============================================================================
 

--- a/console.c
+++ b/console.c
@@ -1471,6 +1471,18 @@ void Con_Printf(const char *fmt, ...)
 	Con_MaskPrint(CON_MASK_PRINT, msg);
 }
 
+/**
+ * @brief      Prints a message to the console with a horizontal rule above and below.
+ *
+ * @param[in]  msg   The message to print
+ */
+void Con_CenterPrint(const char *msg)
+{
+	Con_MaskPrint(CON_MASK_HIDENOTIFY, "\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
+	Con_MaskPrint(CON_MASK_HIDENOTIFY, msg);
+	Con_MaskPrint(CON_MASK_HIDENOTIFY, "\n\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
+}
+
 /*
 ================
 Con_DPrint
@@ -1502,19 +1514,6 @@ void Con_DPrintf(const char *fmt, ...)
 	va_end(argptr);
 
 	Con_MaskPrint(CON_MASK_DEVELOPER, msg);
-}
-
-/*
-================
-Con_CenterPrint
-================
-*/
-void Con_CenterPrint(const char *msg)
-{
-	if (strcmp(msg, con_previouscenterprint))
-		return;
-
-	Con_Print(msg);
 }
 
 

--- a/console.c
+++ b/console.c
@@ -1469,18 +1469,6 @@ void Con_Printf(const char *fmt, ...)
 	Con_MaskPrint(CON_MASK_PRINT, msg);
 }
 
-/**
- * @brief      Prints a message to the console with a horizontal rule above and below.
- *
- * @param[in]  msg   The message to print
- */
-void Con_CenterPrint(const char *msg)
-{
-	Con_MaskPrint(CON_MASK_HIDENOTIFY, "\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
-	Con_MaskPrint(CON_MASK_HIDENOTIFY, msg);
-	Con_MaskPrint(CON_MASK_HIDENOTIFY, "\n\35\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\36\37\n");
-}
-
 /*
 ================
 Con_DPrint

--- a/console.c
+++ b/console.c
@@ -1503,7 +1503,6 @@ void Con_DPrintf(const char *fmt, ...)
 }
 
 
-
 /**
  * @brief      Returns a horizontal line
  * @details    Returns a graphical horizontal line of length len, but never wider than the
@@ -1537,8 +1536,6 @@ const char *Con_Quakebar(int len)
 
 	return bar;
 }
-
-
 
 /**
  * @brief      Left-pad a string with spaces to make it appear centered
@@ -1593,8 +1590,6 @@ void Con_CenterPrintf(int maxLineLength, const char *fmt, ...)
 			Con_MaskPrintf(CON_MASK_HIDENOTIFY, "%s\n", line);
 	}
 }
-
-
 
 /**
  * @brief      Prints a center-aligned message to the console

--- a/console.h
+++ b/console.h
@@ -57,6 +57,8 @@ void Con_Print(const char *txt);
 /// Prints to all appropriate console targets.
 void Con_Printf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 
+void Con_CenterPrint(const char *msg);
+
 /// A Con_Print that only shows up if the "developer" cvar is set.
 void Con_DPrint(const char *msg);
 
@@ -65,7 +67,6 @@ void Con_DPrintf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 void Con_Clear_f(cmd_state_t *cmd);
 void Con_DrawNotify (void);
 
-void Con_CenterPrint(const char *msg);
 
 /// Clear all notify lines.
 void Con_ClearNotify (void);

--- a/console.h
+++ b/console.h
@@ -57,8 +57,6 @@ void Con_Print(const char *txt);
 /// Prints to all appropriate console targets.
 void Con_Printf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 
-void Con_CenterPrint(const char *msg);
-
 /// A Con_Print that only shows up if the "developer" cvar is set.
 void Con_DPrint(const char *msg);
 

--- a/console.h
+++ b/console.h
@@ -63,7 +63,7 @@ void Con_DPrint(const char *msg);
 /// A Con_Printf that only shows up if the "developer" cvar is set
 void Con_DPrintf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 
-const char *Con_Quakebar(int);
+const char *Con_Quakebar(int len, char *bar, size_t bufsize);
 void Con_CenterPrintf(int, const char*, ...);
 void Con_CenterPrint(const char*);
 

--- a/console.h
+++ b/console.h
@@ -64,8 +64,8 @@ void Con_DPrint(const char *msg);
 void Con_DPrintf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 
 const char *Con_Quakebar(int len, char *bar, size_t bufsize);
-void Con_CenterPrintf(int, const char*, ...);
-void Con_CenterPrint(const char*);
+void Con_CenterPrintf(int maxLineLength, const char *fmt, ...) DP_FUNC_PRINTF(2);
+void Con_CenterPrint(const char *str);
 
 void Con_Clear_f(cmd_state_t *cmd);
 void Con_DrawNotify (void);

--- a/console.h
+++ b/console.h
@@ -67,7 +67,6 @@ void Con_DPrintf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 void Con_Clear_f(cmd_state_t *cmd);
 void Con_DrawNotify (void);
 
-
 /// Clear all notify lines.
 void Con_ClearNotify (void);
 void Con_ToggleConsole_f(cmd_state_t *cmd);

--- a/console.h
+++ b/console.h
@@ -62,6 +62,11 @@ void Con_DPrint(const char *msg);
 
 /// A Con_Printf that only shows up if the "developer" cvar is set
 void Con_DPrintf(const char *fmt, ...) DP_FUNC_PRINTF(1);
+
+const char *Con_Quakebar(int);
+void Con_CenterPrintf(int, const char*, ...);
+void Con_CenterPrint(const char*);
+
 void Con_Clear_f(cmd_state_t *cmd);
 void Con_DrawNotify (void);
 

--- a/console.h
+++ b/console.h
@@ -65,6 +65,8 @@ void Con_DPrintf(const char *fmt, ...) DP_FUNC_PRINTF(1);
 void Con_Clear_f(cmd_state_t *cmd);
 void Con_DrawNotify (void);
 
+void Con_CenterPrint(const char *msg);
+
 /// Clear all notify lines.
 void Con_ClearNotify (void);
 void Con_ToggleConsole_f(cmd_state_t *cmd);


### PR DESCRIPTION
Add new function `Con_CenterPrint` which can be used to print messages to the console, without showing onscreen, and with a "horizontal rule" above and below. Use `Con_CenterPrint` to log centerprint messages to the console.

![image](https://github.com/DarkPlacesEngine/darkplaces/assets/424218/8ef0bdc4-7481-4f11-b0a3-d46e4d451c74)

Fixes #98 