### PR TITLE
Give up loading csprogs if a function is missing, but don't error out.

### DIFF
--- a/csprogs.c
+++ b/csprogs.c
@@ -1036,10 +1036,11 @@ void CL_VM_Init (void)
 	if (!prog->loaded)
 	{
 		Mem_Free(csprogsdata);
-		Host_Error("CSQC %s failed to load\n", csprogsfn);
+		Con_Printf("^1CSQC %s failed to load\n", csprogsfn); // log error
+		return;
 	}
 
-	if(cls.demorecording)
+	if (cls.demorecording)
 	{
 		if(cls.demo_lastcsprogssize != csprogsdatasize || cls.demo_lastcsprogscrc != csprogsdatacrc)
 		{

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -2498,8 +2498,13 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char * filename, unsigned char * da
 
 	// check required functions
 	for(i=0 ; i < numrequiredfunc ; i++)
+	{
 		if(PRVM_ED_FindFunction(prog, required_func[i]) == 0)
-			prog->error_cmd("%s: %s not found in %s",prog->name, required_func[i], filename);
+		{
+			Con_Printf("^1%s: %s not found in %s\n", prog->name, required_func[i], filename); // log error
+			return;
+		}
+	}
 
 	PRVM_LoadLNO(prog, filename);
 


### PR DESCRIPTION
Rather than raising a Host_Error if csprogs.dat fails to load, or error_cmd if a function is missing, just log the error and continue so that mods using CSQC-Lite, which doesn't have all the expected functions, can still be played.

Fixes #108 