### PR TITLE
Add sv_gameplayfix_nosquashentities to control entity hitbox squashing

### DIFF
--- a/server.h
+++ b/server.h
@@ -465,6 +465,7 @@ extern cvar_t sv_gameplayfix_q1bsptracelinereportstexture;
 extern cvar_t sv_gameplayfix_unstickplayers;
 extern cvar_t sv_gameplayfix_unstickentities;
 extern cvar_t sv_gameplayfix_fixedcheckwatertransition;
+extern cvar_t sv_gameplayfix_nosquashentities;
 extern cvar_t sv_gravity;
 extern cvar_t sv_idealpitchscale;
 extern cvar_t sv_jumpstep;

--- a/sv_main.c
+++ b/sv_main.c
@@ -129,6 +129,7 @@ cvar_t sv_gameplayfix_q1bsptracelinereportstexture = {CF_SERVER, "sv_gameplayfix
 cvar_t sv_gameplayfix_unstickplayers = {CF_SERVER, "sv_gameplayfix_unstickplayers", "0", "big hack to try and fix the rare case of MOVETYPE_WALK entities getting stuck in the world clipping hull."};
 cvar_t sv_gameplayfix_unstickentities = {CF_SERVER, "sv_gameplayfix_unstickentities", "1", "hack to check if entities are crossing world collision hull and try to move them to the right position, superseded by sv_gameplayfix_nudgeoutofsolid"};
 cvar_t sv_gameplayfix_fixedcheckwatertransition = {CF_SERVER, "sv_gameplayfix_fixedcheckwatertransition", "1", "fix two very stupid bugs in SV_CheckWaterTransition when watertype is CONTENTS_EMPTY (the bugs causes waterlevel to be 1 on first frame, -1 on second frame - the fix makes it 0 on both frames)"};
+cvar_t sv_gameplayfix_nosquashentities = {CF_SERVER, "sv_gameplayfix_nosquashentities", "0", "Do not resize entity bounding boxes when the entity is squashed by movers."};
 cvar_t sv_gravity = {CF_SERVER | CF_NOTIFY, "sv_gravity","800", "how fast you fall (512 = roughly earth gravity)"};
 cvar_t sv_init_frame_count = {CF_SERVER, "sv_init_frame_count", "2", "number of frames to run to allow everything to settle before letting clients connect"};
 cvar_t sv_idealpitchscale = {CF_SERVER, "sv_idealpitchscale","0.8", "how much to look up/down slopes and stairs when not using freelook"};
@@ -612,6 +613,7 @@ void SV_Init (void)
 	Cvar_RegisterVariable (&sv_gameplayfix_unstickplayers);
 	Cvar_RegisterVariable (&sv_gameplayfix_unstickentities);
 	Cvar_RegisterVariable (&sv_gameplayfix_fixedcheckwatertransition);
+	Cvar_RegisterVariable (&sv_gameplayfix_nosquashentities);
 	Cvar_RegisterVariable (&sv_qcstats);
 	Cvar_RegisterVariable (&sv_gravity);
 	Cvar_RegisterVariable (&sv_init_frame_count);

--- a/sv_main.c
+++ b/sv_main.c
@@ -129,7 +129,7 @@ cvar_t sv_gameplayfix_q1bsptracelinereportstexture = {CF_SERVER, "sv_gameplayfix
 cvar_t sv_gameplayfix_unstickplayers = {CF_SERVER, "sv_gameplayfix_unstickplayers", "0", "big hack to try and fix the rare case of MOVETYPE_WALK entities getting stuck in the world clipping hull."};
 cvar_t sv_gameplayfix_unstickentities = {CF_SERVER, "sv_gameplayfix_unstickentities", "1", "hack to check if entities are crossing world collision hull and try to move them to the right position, superseded by sv_gameplayfix_nudgeoutofsolid"};
 cvar_t sv_gameplayfix_fixedcheckwatertransition = {CF_SERVER, "sv_gameplayfix_fixedcheckwatertransition", "1", "fix two very stupid bugs in SV_CheckWaterTransition when watertype is CONTENTS_EMPTY (the bugs causes waterlevel to be 1 on first frame, -1 on second frame - the fix makes it 0 on both frames)"};
-cvar_t sv_gameplayfix_nosquashentities = {CF_SERVER, "sv_gameplayfix_nosquashentities", "0", "Do not resize entity bounding boxes when the entity is squashed by movers."};
+cvar_t sv_gameplayfix_nosquashentities = {CF_SERVER, "sv_gameplayfix_nosquashentities", "0", "Entity hitboxes will not be resized or disabled when they are crushed by movers, and will continue to be affected by movers."};
 cvar_t sv_gravity = {CF_SERVER | CF_NOTIFY, "sv_gravity","800", "how fast you fall (512 = roughly earth gravity)"};
 cvar_t sv_init_frame_count = {CF_SERVER, "sv_init_frame_count", "2", "number of frames to run to allow everything to settle before letting clients connect"};
 cvar_t sv_idealpitchscale = {CF_SERVER, "sv_idealpitchscale","0.8", "how much to look up/down slopes and stairs when not using freelook"};

--- a/sv_phys.c
+++ b/sv_phys.c
@@ -1936,6 +1936,8 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 				// corpse
 				if (sv_gameplayfix_nosquashentities.integer == 0)
 				{
+					// When sv_gameplayfix_nosquashentities is disabled, entity hitboxes will be squashed when
+					// the entity is crushed by a mover, preventing it from being interacted with again
 					PRVM_serveredictvector(check, mins)[0] = PRVM_serveredictvector(check, mins)[1] = 0;
 					VectorCopy (PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs));
 				}

--- a/sv_phys.c
+++ b/sv_phys.c
@@ -1820,16 +1820,10 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		}
 
 		if (PRVM_serveredictedict(check, owner) == pusherprog)
-		{
-			// Con_Printf("PRVM_serveredictedict(check, owner) == pusherprog\n");
 			continue;
-		}
 
 		if (pusherowner == PRVM_EDICT_TO_PROG(check))
-		{
-			// Con_Printf("pusherowner == PRVM_EDICT_TO_PROG(check)\n");
 			continue;
-		}
 
 		//Con_Printf("%i %s ", PRVM_NUM_FOR_EDICT(check), PRVM_GetString(PRVM_serveredictstring(check, classname)));
 
@@ -1843,8 +1837,6 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		// final position, move it
 		if (!((int)PRVM_serveredictfloat(check, flags) & FL_ONGROUND) || PRVM_PROG_TO_EDICT(PRVM_serveredictedict(check, groundentity)) != pusher)
 		{
-			// Con_Printf("!((int)PRVM_serveredictfloat(check, flags) & FL_ONGROUND) || PRVM_PROG_TO_EDICT(PRVM_serveredictedict(check, groundentity)) != pusher\n");
-
 			VectorCopy(PRVM_serveredictvector(pusher, mins), pushermins);
 			VectorCopy(PRVM_serveredictvector(pusher, maxs), pushermaxs);
 			VectorCopy(PRVM_serveredictvector(check, origin), checkorigin);
@@ -1885,8 +1877,6 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		// physics objects need better collisions than this code can do
 		if (movetype == MOVETYPE_PHYSICS)
 		{
-			// Con_Printf("movetype == MOVETYPE_PHYSIC\n");
-
 			VectorAdd(PRVM_serveredictvector(check, origin), move, PRVM_serveredictvector(check, origin));
 			SV_LinkEdict(check);
 			SV_LinkEdict_TouchAreaGrid(check);
@@ -1922,8 +1912,6 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		Collision_ClipToGenericEntity(&trace, pushermodel, pusher->priv.server->frameblend, &pusher->priv.server->skeleton, pushermins, pushermaxs, SUPERCONTENTS_BODY, &pusherfinalmatrix, &pusherfinalimatrix, checkorigin, checkmins, checkmaxs, checkorigin, checkcontents, 0, 0, collision_extendmovelength.value);
 		if (trace.startsolid)
 		{
-			// Con_Printf("trace.startsolid is true\n");
-
 			vec3_t move2;
 			if(SV_NudgeOutOfSolid_PivotIsKnownGood(check, pivot))
 			{
@@ -1942,14 +1930,9 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 
 			// fail the move
 			if (PRVM_serveredictvector(check, mins)[0] == PRVM_serveredictvector(check, maxs)[0])
-			{
-				// Con_Printf("PRVM_serveredictvector(check, mins)[0] == PRVM_serveredictvector(check, maxs)[0]\n");
 				continue;
-			}
-
 			if (PRVM_serveredictfloat(check, solid) == SOLID_NOT || PRVM_serveredictfloat(check, solid) == SOLID_TRIGGER)
 			{
-				// Con_Printf("PRVM_serveredictfloat(check, solid) == SOLID_NOT || PRVM_serveredictfloat(check, solid) == SOLID_TRIGGER\n");
 				// corpse
 				// PRVM_serveredictvector(check, mins)[0] = PRVM_serveredictvector(check, mins)[1] = 0;
 				// VectorCopy (PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs));
@@ -1973,7 +1956,6 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 			// if the pusher has a "blocked" function, call it, otherwise just stay in place until the obstacle is gone
 			if (PRVM_serveredictfunction(pusher, blocked))
 			{
-				// Con_Printf("PRVM_serveredictfunction(pusher, blocked)\n");
 				PRVM_serverglobalfloat(time) = sv.time;
 				PRVM_serverglobaledict(self) = PRVM_EDICT_TO_PROG(pusher);
 				PRVM_serverglobaledict(other) = PRVM_EDICT_TO_PROG(check);

--- a/sv_phys.c
+++ b/sv_phys.c
@@ -1934,8 +1934,11 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 			if (PRVM_serveredictfloat(check, solid) == SOLID_NOT || PRVM_serveredictfloat(check, solid) == SOLID_TRIGGER)
 			{
 				// corpse
-				// PRVM_serveredictvector(check, mins)[0] = PRVM_serveredictvector(check, mins)[1] = 0;
-				// VectorCopy (PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs));
+				if (sv_gameplayfix_nosquashentities.integer == 0)
+				{
+					PRVM_serveredictvector(check, mins)[0] = PRVM_serveredictvector(check, mins)[1] = 0;
+					VectorCopy (PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs));
+				}
 				continue;
 			}
 

--- a/sv_phys.c
+++ b/sv_phys.c
@@ -1820,10 +1820,16 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		}
 
 		if (PRVM_serveredictedict(check, owner) == pusherprog)
+		{
+			// Con_Printf("PRVM_serveredictedict(check, owner) == pusherprog\n");
 			continue;
+		}
 
 		if (pusherowner == PRVM_EDICT_TO_PROG(check))
+		{
+			// Con_Printf("pusherowner == PRVM_EDICT_TO_PROG(check)\n");
 			continue;
+		}
 
 		//Con_Printf("%i %s ", PRVM_NUM_FOR_EDICT(check), PRVM_GetString(PRVM_serveredictstring(check, classname)));
 
@@ -1837,6 +1843,8 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		// final position, move it
 		if (!((int)PRVM_serveredictfloat(check, flags) & FL_ONGROUND) || PRVM_PROG_TO_EDICT(PRVM_serveredictedict(check, groundentity)) != pusher)
 		{
+			// Con_Printf("!((int)PRVM_serveredictfloat(check, flags) & FL_ONGROUND) || PRVM_PROG_TO_EDICT(PRVM_serveredictedict(check, groundentity)) != pusher\n");
+
 			VectorCopy(PRVM_serveredictvector(pusher, mins), pushermins);
 			VectorCopy(PRVM_serveredictvector(pusher, maxs), pushermaxs);
 			VectorCopy(PRVM_serveredictvector(check, origin), checkorigin);
@@ -1846,7 +1854,7 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 			//trace = SV_TraceBox(PRVM_serveredictvector(check, origin), PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs), PRVM_serveredictvector(check, origin), MOVE_NOMONSTERS, check, checkcontents);
 			if (!trace.startsolid)
 			{
-				//Con_Printf("- not in solid\n");
+				// Con_Printf("- not in solid\n");
 				continue;
 			}
 		}
@@ -1877,6 +1885,8 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		// physics objects need better collisions than this code can do
 		if (movetype == MOVETYPE_PHYSICS)
 		{
+			// Con_Printf("movetype == MOVETYPE_PHYSIC\n");
+
 			VectorAdd(PRVM_serveredictvector(check, origin), move, PRVM_serveredictvector(check, origin));
 			SV_LinkEdict(check);
 			SV_LinkEdict_TouchAreaGrid(check);
@@ -1912,6 +1922,8 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 		Collision_ClipToGenericEntity(&trace, pushermodel, pusher->priv.server->frameblend, &pusher->priv.server->skeleton, pushermins, pushermaxs, SUPERCONTENTS_BODY, &pusherfinalmatrix, &pusherfinalimatrix, checkorigin, checkmins, checkmaxs, checkorigin, checkcontents, 0, 0, collision_extendmovelength.value);
 		if (trace.startsolid)
 		{
+			// Con_Printf("trace.startsolid is true\n");
+
 			vec3_t move2;
 			if(SV_NudgeOutOfSolid_PivotIsKnownGood(check, pivot))
 			{
@@ -1930,12 +1942,17 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 
 			// fail the move
 			if (PRVM_serveredictvector(check, mins)[0] == PRVM_serveredictvector(check, maxs)[0])
+			{
+				// Con_Printf("PRVM_serveredictvector(check, mins)[0] == PRVM_serveredictvector(check, maxs)[0]\n");
 				continue;
+			}
+
 			if (PRVM_serveredictfloat(check, solid) == SOLID_NOT || PRVM_serveredictfloat(check, solid) == SOLID_TRIGGER)
 			{
+				// Con_Printf("PRVM_serveredictfloat(check, solid) == SOLID_NOT || PRVM_serveredictfloat(check, solid) == SOLID_TRIGGER\n");
 				// corpse
-				PRVM_serveredictvector(check, mins)[0] = PRVM_serveredictvector(check, mins)[1] = 0;
-				VectorCopy (PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs));
+				// PRVM_serveredictvector(check, mins)[0] = PRVM_serveredictvector(check, mins)[1] = 0;
+				// VectorCopy (PRVM_serveredictvector(check, mins), PRVM_serveredictvector(check, maxs));
 				continue;
 			}
 
@@ -1956,6 +1973,7 @@ static void SV_PushMove (prvm_edict_t *pusher, float movetime)
 			// if the pusher has a "blocked" function, call it, otherwise just stay in place until the obstacle is gone
 			if (PRVM_serveredictfunction(pusher, blocked))
 			{
+				// Con_Printf("PRVM_serveredictfunction(pusher, blocked)\n");
 				PRVM_serverglobalfloat(time) = sv.time;
 				PRVM_serverglobaledict(self) = PRVM_EDICT_TO_PROG(pusher);
 				PRVM_serverglobaledict(other) = PRVM_EDICT_TO_PROG(check);


### PR DESCRIPTION
Adds new cvar `sv_gameplayfix_nosquashentities` which, when enabled, will prevent entity hitboxes being resized when the entity is squashed by a mover. This means the entity can continue to interact with pushers and movers. Fixes #155.