### PR TITLE
Properly unescape escaped characters in save file when loading

### DIFF
--- a/progsvm.h
+++ b/progsvm.h
@@ -850,7 +850,7 @@ void PRVM_ED_ClearEdict(prvm_prog_t *prog, prvm_edict_t *e);
 void PRVM_PrintFunctionStatements(prvm_prog_t *prog, const char *name);
 void PRVM_ED_Print(prvm_prog_t *prog, prvm_edict_t *ed, const char *wildcard_fieldname);
 void PRVM_ED_Write(prvm_prog_t *prog, struct qfile_s *f, prvm_edict_t *ed);
-const char *PRVM_ED_ParseEdict(prvm_prog_t *prog, const char *data, prvm_edict_t *ent);
+const char *PRVM_ED_ParseEdict(prvm_prog_t *prog, const char *data, prvm_edict_t *ent, qbool saveload);
 
 void PRVM_ED_WriteGlobals(prvm_prog_t *prog, struct qfile_s *f);
 void PRVM_ED_ParseGlobals(prvm_prog_t *prog, const char *data);

--- a/prvm_cmds.c
+++ b/prvm_cmds.c
@@ -3069,7 +3069,7 @@ void VM_parseentitydata(prvm_prog_t *prog)
 	if (!COM_ParseToken_Simple(&data, false, false, true) || com_token[0] != '{' )
 		prog->error_cmd("VM_parseentitydata: %s: Couldn't parse entity data:\n%s", prog->name, data );
 
-	PRVM_ED_ParseEdict (prog, data, ent);
+	PRVM_ED_ParseEdict (prog, data, ent, false);
 }
 
 /*

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -1322,7 +1322,8 @@ const char *PRVM_ED_ParseEdict (prvm_prog_t *prog, const char *data, prvm_edict_
 		}
 
 	// parse value
-		// If loading a save, unescape characters. Otherwise, load them as they are
+		// If loading a save, unescape characters (they're escaped when saving).
+		// Otherwise, load them as they are (BSP compilers don't support escaping).
 		if (!COM_ParseToken_Simple(&data, false, saveload, true))
 			prog->error_cmd("PRVM_ED_ParseEdict: EOF without closing brace");
 		if (developer_entityparsing.integer)
@@ -1356,7 +1357,7 @@ const char *PRVM_ED_ParseEdict (prvm_prog_t *prog, const char *data, prvm_edict_
 			dpsnprintf (com_token, sizeof(com_token), "0 %s 0", temp);
 		}
 
-		if (!PRVM_ED_ParseEpair(prog, ent, key, com_token, strcmp(keyname, "wad") != 0))
+		if (!PRVM_ED_ParseEpair(prog, ent, key, com_token, false))
 			prog->error_cmd("PRVM_ED_ParseEdict: parse error");
 	}
 

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -1276,7 +1276,7 @@ ed should be a properly initialized empty edict.
 Used for initial level load and for savegames.
 ====================
 */
-const char *PRVM_ED_ParseEdict (prvm_prog_t *prog, const char *data, prvm_edict_t *ent)
+const char *PRVM_ED_ParseEdict (prvm_prog_t *prog, const char *data, prvm_edict_t *ent, qbool saveload)
 {
 	mdef_t *key;
 	qbool anglehack;
@@ -1322,7 +1322,8 @@ const char *PRVM_ED_ParseEdict (prvm_prog_t *prog, const char *data, prvm_edict_
 		}
 
 	// parse value
-		if (!COM_ParseToken_Simple(&data, false, false, true))
+		// If loading a save, unescape characters. Otherwise, load them as they are
+		if (!COM_ParseToken_Simple(&data, false, saveload, true))
 			prog->error_cmd("PRVM_ED_ParseEdict: EOF without closing brace");
 		if (developer_entityparsing.integer)
 			Con_Printf(" \"%s\"\n", com_token);
@@ -1526,7 +1527,7 @@ void PRVM_ED_LoadFromFile (prvm_prog_t *prog, const char *data)
 		if (ent != prog->edicts)	// hack
 			memset (ent->fields.fp, 0, prog->entityfields * sizeof(prvm_vec_t));
 
-		data = PRVM_ED_ParseEdict (prog, data, ent);
+		data = PRVM_ED_ParseEdict (prog, data, ent, false);
 		parsed++;
 
 		// remove the entity ?

--- a/sv_save.c
+++ b/sv_save.c
@@ -434,7 +434,7 @@ void SV_Loadgame_f(cmd_state_t *cmd)
 			if(developer_entityparsing.integer)
 				Con_Printf("SV_Loadgame_f: loading edict %d\n", entnum);
 
-			PRVM_ED_ParseEdict (prog, start, ent);
+			PRVM_ED_ParseEdict (prog, start, ent, true);
 
 			// link it into the bsp tree
 			if (!ent->free)


### PR DESCRIPTION
Modified PRVM_ED_ParseEdict to determine whether it is loading a save or not, and unescape variables if loading a save. Fixes #81 