### PR TITLE
Only use BoxTouchingVisibleLeafs when not using r_novis

### DIFF
--- a/gl_rmain.c
+++ b/gl_rmain.c
@@ -4007,7 +4007,7 @@ static void R_View_UpdateEntityVisible (void)
 	if (!r_drawexteriormodel.integer)
 		renderimask |= RENDER_EXTERIORMODEL;
 	memset(r_refdef.viewcache.entityvisible, 0, r_refdef.scene.numentities);
-	if (r_refdef.scene.worldmodel && r_refdef.scene.worldmodel->brush.BoxTouchingVisibleLeafs)
+	if (r_refdef.scene.worldmodel && (!r_novis.integer && r_refdef.scene.worldmodel->brush.BoxTouchingVisibleLeafs))
 	{
 		// worldmodel can check visibility
 		for (i = 0;i < r_refdef.scene.numentities;i++)

--- a/gl_rmain.c
+++ b/gl_rmain.c
@@ -4007,7 +4007,7 @@ static void R_View_UpdateEntityVisible (void)
 	if (!r_drawexteriormodel.integer)
 		renderimask |= RENDER_EXTERIORMODEL;
 	memset(r_refdef.viewcache.entityvisible, 0, r_refdef.scene.numentities);
-	if (r_refdef.scene.worldmodel && (!r_novis.integer && r_refdef.scene.worldmodel->brush.BoxTouchingVisibleLeafs))
+	if (r_refdef.scene.worldmodel && !r_novis.integer && r_refdef.scene.worldmodel->brush.BoxTouchingVisibleLeafs)
 	{
 		// worldmodel can check visibility
 		for (i = 0;i < r_refdef.scene.numentities;i++)


### PR DESCRIPTION
Updates the entity visibility check in `R_View_UpdateEntityVisible` so that with `r_novis 1` entities are rendered when the player is outside of the level.

Resolves #188 

`r_novis 0`
![image](https://github.com/user-attachments/assets/33722174-e64d-4c30-b60a-7005827a2fd5)

`r_novis 1`
![image](https://github.com/user-attachments/assets/d9fa923e-942a-46e6-87da-7007d8da6ef6)
