### PR TITLE
Change directory text colour in console from dark to light blue

### DIFF
--- a/console.c
+++ b/console.c
@@ -3071,7 +3071,8 @@ int Con_CompleteCommandLine(cmd_state_t *cmd, qbool is_console)
 						Con_Printf("\n%i possible filenames\n", resultbuf.numstrings + dirbuf.numstrings);
 						for(i = 0; i < dirbuf.numstrings; ++i)
 						{
-							Con_Printf("^4%s^7/\n", dirbuf.strings[i]);
+							// Print directory names/paths to the console in light blue
+							Con_Printf("^5%s^7/\n", dirbuf.strings[i]);
 						}
 						for(i = 0; i < resultbuf.numstrings; ++i)
 						{


### PR DESCRIPTION
Updates the console text colour for directories from dark blue to light blue. Fixed #196 

![colour-old](https://github.com/user-attachments/assets/1e850b31-39a5-48b6-8804-6dd679f2f0f0)
![colour-new](https://github.com/user-attachments/assets/74124d33-cd0c-4b14-bf21-c65f0709cfd3)
