### PR TITLE
Do more checks before flagging a model to be lit

### DIFF
--- a/cl_main.c
+++ b/cl_main.c
@@ -1306,7 +1306,7 @@ static void CL_UpdateNetworkEntity(entity_t *e, int recursionlimit, qbool interp
 	if (e->state_current.number == cl.viewentity)
 		e->render.flags |= RENDER_EXTERIORMODEL;
 	// either fullbright or lit
-	if(!r_fullbright.integer)
+	if(!r_fullbright.integer && e->render.model->lit)
 	{
 		if (!(e->render.effects & EF_FULLBRIGHT))
 			e->render.flags |= RENDER_LIGHT;
@@ -1720,7 +1720,7 @@ static void CL_RelinkWorld(void)
 	// FIXME: this should be done at load
 	ent->render.matrix = identitymatrix;
 	ent->render.flags = RENDER_SHADOW;
-	if (!r_fullbright.integer)
+	if (!r_fullbright.integer && ent->render.model->lit)
 		ent->render.flags |= RENDER_LIGHT;
 	VectorSet(ent->render.colormod, 1, 1, 1);
 	VectorSet(ent->render.glowmod, 1, 1, 1);
@@ -1745,7 +1745,7 @@ static void CL_RelinkStaticEntities(void)
 		// need to re-fetch the model pointer
 		e->render.model = CL_GetModelByIndex(e->state_baseline.modelindex);
 		// either fullbright or lit
-		if(!r_fullbright.integer)
+		if(!r_fullbright.integer && e->render.model->lit)
 		{
 			if (!(e->render.effects & EF_FULLBRIGHT))
 				e->render.flags |= RENDER_LIGHT;

--- a/model_brush.c
+++ b/model_brush.c
@@ -2714,7 +2714,6 @@ static void Mod_Q1BSP_LoadFaces(sizebuf_t *sb)
 		if (lightmapoffset == -1)
 		{
 			surface->lightmapinfo->samples = NULL;
-#if 1
 			// give non-lightmapped water a 1x white lightmap
 			if (!loadmodel->brush.isq2bsp && surface->texture->name[0] == '*' && (surface->lightmapinfo->texinfo->q1flags & TEX_SPECIAL) && ssize <= 256 && tsize <= 256)
 			{
@@ -2722,7 +2721,6 @@ static void Mod_Q1BSP_LoadFaces(sizebuf_t *sb)
 				surface->lightmapinfo->styles[0] = 0;
 				memset(surface->lightmapinfo->samples, 128, ssize * tsize * 3);
 			}
-#endif
 		}
 		else if (loadmodel->brush.ishlbsp || loadmodel->brush.isq2bsp) // LadyHavoc: HalfLife map (bsp version 30)
 			surface->lightmapinfo->samples = loadmodel->brushq1.lightdata + lightmapoffset;
@@ -2734,7 +2732,7 @@ static void Mod_Q1BSP_LoadFaces(sizebuf_t *sb)
 		}
 
 		// check if we should apply a lightmap to this
-		if (!(surface->lightmapinfo->texinfo->q1flags & TEX_SPECIAL) || surface->lightmapinfo->samples)
+		if ((!(surface->lightmapinfo->texinfo->q1flags & TEX_SPECIAL) || surface->lightmapinfo->samples) && loadmodel->brushq1.lightdata)
 		{
 			if (ssize > 256 || tsize > 256)
 				Host_Error("Bad surface extents");


### PR DESCRIPTION
Do not set the RENDER_LIGHT flag on an entity if it is not flagged to be lit via its model->lit property.
Check we have lightmap data before enabling the lit property on a loadmodel.
Fixes #103 