### PR TITLE
fix(fs.c, windows, ucrt64): fix getcwd for windows ucrt64 builds

### DIFF
--- a/console.c
+++ b/console.c
@@ -3071,7 +3071,8 @@ int Con_CompleteCommandLine(cmd_state_t *cmd, qbool is_console)
 						Con_Printf("\n%i possible filenames\n", resultbuf.numstrings + dirbuf.numstrings);
 						for(i = 0; i < dirbuf.numstrings; ++i)
 						{
-							Con_Printf("^4%s^7/\n", dirbuf.strings[i]);
+							// Print directory names/paths to the console in light blue
+							Con_Printf("^5%s^7/\n", dirbuf.strings[i]);
 						}
 						for(i = 0; i < resultbuf.numstrings; ++i)
 						{

--- a/fs.c
+++ b/fs.c
@@ -78,7 +78,7 @@
 
 // windows wchar helpers
 #ifdef WIN32
-# define MAX_OSWPATH (MAX_OSPATH * sizeof(wchar))
+# define MAX_OSWPATH MAX_OSPATH
 # define WPATHDEF(var) wchar var[MAX_OSWPATH]
 #else
 # define WPATHDEF(var) ;
@@ -2197,7 +2197,7 @@ static void FS_Init_Dir (void)
 #else
 	// use the working directory
 	#ifdef WIN32
-		_wgetcwd(fs_basedirw, sizeof(fs_basedirw));
+		GetCurrentDirectoryW(sizeof(fs_basedirw), fs_basedirw);
 		NARROW(fs_basedirw, fs_basedir);
 	#else
 		getcwd(fs_basedir, sizeof(fs_basedir));

--- a/fs.c
+++ b/fs.c
@@ -2197,7 +2197,7 @@ static void FS_Init_Dir (void)
 #else
 	// use the working directory
 	#ifdef WIN32
-		GetCurrentDirectoryW(sizeof(fs_basedirw), fs_basedirw);
+		GetCurrentDirectoryW(sizeof(fs_basedirw) / sizeof(*fs_basedirw), fs_basedirw);
 		NARROW(fs_basedirw, fs_basedir);
 	#else
 		getcwd(fs_basedir, sizeof(fs_basedir));


### PR DESCRIPTION
I'm really late 🥲 With this patch, compiling darkplaces master with msys2 ucrt64 environment is back to normal.

History:
- A commit was introduced to have current working directory known by the engine to fix some mods:
  - https://gitlab.com/xonotic/darkplaces/-/commit/1f4743e930b01c520372c570fb6c936ed461ee64
  - To fix: https://github.com/DarkPlacesEngine/DarkPlaces/issues/172
- I submitted a patch, because that code breaks games in Windows non-ascii paths:
  - https://gitlab.com/xonotic/darkplaces/-/merge_requests/153
- The `_getcwd` function used in the patch is causing segmentation fault in ucrt64 environment:
  - https://gitlab.com/xonotic/darkplaces/-/issues/422
- We need a win32 native function to avoid this segmentation fault — this pull request

Closes [gitlab.com/xonotic/darkplaces#422](https://gitlab.com/xonotic/darkplaces/-/issues/422).
