### PR TITLE
Add FTEQCC pointer instructions

### DIFF
--- a/pr_comp.h
+++ b/pr_comp.h
@@ -320,6 +320,65 @@ typedef enum opcode_e
 	OP_STOREF_F,	//1 fpu element...
 	OP_STOREF_S,	//1 string reference
 	OP_STOREF_I,	//1 non-string reference/int
+
+	//fteqw r5744+
+	OP_STOREP_B,//((char*)b)[(int)c] = (int)a
+	OP_LOADP_B,	//(int)c = *(char*)
+
+	//fteqw r5768+
+	//opcodes for 32bit uints
+	OP_LE_U,		//aka GT
+	OP_LT_U,		//aka GE
+	OP_DIV_U,		//don't need mul+add+sub
+	OP_RSHIFT_U,	//lshift is the same for signed+unsigned
+
+	//opcodes for 64bit ints
+	OP_ADD_I64,
+	OP_SUB_I64,
+	OP_MUL_I64,
+	OP_DIV_I64,
+	OP_BITAND_I64,
+	OP_BITOR_I64,
+	OP_BITXOR_I64,
+	OP_LSHIFT_I64I,
+	OP_RSHIFT_I64I,
+	OP_LE_I64,		//aka GT
+	OP_LT_I64,		//aka GE
+	OP_EQ_I64,
+	OP_NE_I64,
+	//extra opcodes for 64bit uints
+	OP_LE_U64,		//aka GT
+	OP_LT_U64,		//aka GE
+	OP_DIV_U64,
+	OP_RSHIFT_U64I,
+
+	//general 64bitness
+	OP_STORE_I64,
+	OP_STOREP_I64,
+	OP_STOREF_I64,
+	OP_LOAD_I64,
+	OP_LOADA_I64,
+	OP_LOADP_I64,
+	//various conversions for our 64bit types (yay type promotion)
+	OP_CONV_UI64, //zero extend
+	OP_CONV_II64, //sign extend
+	OP_CONV_I64I,	//truncate
+	OP_CONV_FD,	//extension
+	OP_CONV_DF,	//truncation
+	OP_CONV_I64F,	//logically a promotion (always signed)
+	OP_CONV_FI64,	//demotion (always signed)
+	OP_CONV_I64D,	//'promotion' (always signed)
+	OP_CONV_DI64,	//demotion (always signed)
+
+	//opcodes for doubles.
+	OP_ADD_D,
+	OP_SUB_D,
+	OP_MUL_D,
+	OP_DIV_D,
+	OP_LE_D,
+	OP_LT_D,
+	OP_EQ_D,
+	OP_NE_D,
 }
 opcode_t;
 

--- a/pr_comp.h
+++ b/pr_comp.h
@@ -67,10 +67,10 @@ typedef enum opcode_e
 	OP_NE_E,
 	OP_NE_FNC,
 
-	OP_LE,
-	OP_GE,
-	OP_LT,
-	OP_GT,
+	OP_LE_F,
+	OP_GE_F,
+	OP_LT_F,
+	OP_GT_F,
 
 	OP_LOAD_F,
 	OP_LOAD_V,
@@ -114,14 +114,14 @@ typedef enum opcode_e
 	OP_CALL8,
 	OP_STATE,
 	OP_GOTO,
-	OP_AND,
-	OP_OR,
+	OP_AND_F,
+	OP_OR_F,
 
-	OP_BITAND,
-	OP_BITOR,
+	OP_BITAND_F,
+	OP_BITOR_F,
 
 	// TODO: actually support Hexen 2?
-	
+
 	OP_MULSTORE_F,	//66 redundant, for h2 compat
 	OP_MULSTORE_VF,	//67 redundant, for h2 compat
 	OP_MULSTOREP_F,	//68
@@ -194,11 +194,11 @@ typedef enum opcode_e
 	OP_SUB_FI,
 	OP_SUB_IF,
 
-	OP_CONV_IF,
-	OP_CONV_FI,
-	
-	OP_LOADP_IF,
-	OP_LOADP_FI,
+	OP_CONV_ITOF,
+	OP_CONV_FTOI,
+
+	OP_LOADP_ITOF,
+	OP_LOADP_FTOI,
 
 	OP_LOAD_I,
 
@@ -230,7 +230,7 @@ typedef enum opcode_e
 	OP_ADD_PIW,
 
 	OP_LOADA_F,
-	OP_LOADA_V,	
+	OP_LOADA_V,
 	OP_LOADA_S,
 	OP_LOADA_ENT,
 	OP_LOADA_FLD,
@@ -241,7 +241,7 @@ typedef enum opcode_e
 	OP_LOAD_P,
 
 	OP_LOADP_F,
-	OP_LOADP_V,	
+	OP_LOADP_V,
 	OP_LOADP_S,
 	OP_LOADP_ENT,
 	OP_LOADP_FLD,
@@ -252,7 +252,7 @@ typedef enum opcode_e
 	OP_GE_I,
 	OP_LT_I,
 	OP_GT_I,
-	
+
 	OP_LE_IF,
 	OP_GE_IF,
 	OP_LT_IF,
@@ -295,7 +295,7 @@ typedef enum opcode_e
 	OP_GSTOREP_ENT,
 	OP_GSTOREP_FLD,
 	OP_GSTOREP_S,
-	OP_GSTOREP_FNC,		
+	OP_GSTOREP_FNC,
 	OP_GSTOREP_V,
 	OP_GADDRESS,
 	OP_GLOAD_I,

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -2316,7 +2316,6 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 			prog->statements[i].operand[1] =
 			prog->statements[i].operand[2] = op;
 			break;
-		case OP_STORE_I:
 		case OP_ADD_I:
 		case OP_ADD_FI:
 		case OP_ADD_IF:
@@ -2326,7 +2325,6 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_CONV_IF:
 		case OP_CONV_FI:
 		case OP_LOAD_I:
-		case OP_STOREP_I:
 		case OP_BITAND_I:
 		case OP_BITOR_I:
 		case OP_MUL_I:
@@ -2335,7 +2333,6 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_NE_I:
 		case OP_NOT_I:
 		case OP_DIV_VF:
-		case OP_STORE_P:
 		case OP_LE_I:
 		case OP_GE_I:
 		case OP_LT_I:
@@ -2419,6 +2416,23 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_LOAD_S:
 		case OP_LOAD_FNC:
 		case OP_LOAD_V:
+		case OP_LOAD_P:
+		case OP_ADD_PIW:
+		case OP_GLOBALADDRESS:
+		case OP_LOADA_F:
+		case OP_LOADA_V:
+		case OP_LOADA_S:
+		case OP_LOADA_ENT:
+		case OP_LOADA_FLD:
+		case OP_LOADA_FNC:
+		case OP_LOADA_I:
+		case OP_LOADP_F:
+		case OP_LOADP_V:
+		case OP_LOADP_S:
+		case OP_LOADP_ENT:
+		case OP_LOADP_FLD:
+		case OP_LOADP_FNC:
+		case OP_LOADP_I:
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals || c >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d)", __func__, i);
 			prog->statements[i].op = op;
@@ -2446,6 +2460,7 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_STOREP_S:
 		case OP_STOREP_FNC:
 		case OP_STOREP_V:
+		case OP_STOREP_I:
 			if (c)	//Spike -- DP is alergic to pointers in QC. Try to avoid too many nasty surprises.
 				Con_DPrintf("%s: storep-with-offset is not permitted in %s\n", __func__, prog->name);
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals || c >= prog->progs_numglobals)
@@ -2461,6 +2476,8 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_STORE_S:
 		case OP_STORE_FNC:
 		case OP_STORE_V:
+		case OP_STORE_I:
+		case OP_STORE_P:
 		case OP_STATE:
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d) in %s", __func__, i, prog->name);

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -2293,6 +2293,8 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 			b = (short)b;
 			if (a >= prog->progs_numglobals || b + i < 0 || b + i >= prog->progs_numstatements)
 				prog->error_cmd("%s: out of bounds IF/IFNOT (statement %d) in %s", __func__, i, prog->name);
+			if (c)
+				Con_DPrintf("%s: unexpected offset on binary opcode in %s\n", __func__, prog->name);
 			prog->statements[i].op = op;
 			prog->statements[i].operand[0] = remapglobal(a);
 			prog->statements[i].operand[1] = b;
@@ -2302,6 +2304,8 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 			a = (short)a;
 			if (a + i < 0 || a + i >= prog->progs_numstatements)
 				prog->error_cmd("%s: out of bounds GOTO (statement %d) in %s", __func__, i, prog->name);
+			if (b || c)
+				Con_DPrintf("%s: unexpected offset on unary opcode in %s\n", __func__, prog->name);
 			prog->statements[i].op = op;
 			prog->statements[i].operand[0] = a;
 			prog->statements[i].operand[1] = -1;
@@ -2316,6 +2320,7 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 			prog->statements[i].operand[1] =
 			prog->statements[i].operand[2] = op;
 			break;
+		// global global global
 		case OP_ADD_I:
 		case OP_ADD_FI:
 		case OP_ADD_IF:
@@ -2380,8 +2385,6 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_GLOAD_FNC:
 		case OP_BOUNDCHECK:
 		case OP_GLOAD_V:
-
-		// global global global
 		case OP_ADD_F:
 		case OP_ADD_V:
 		case OP_SUB_F:
@@ -2433,6 +2436,13 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_LOADP_FLD:
 		case OP_LOADP_FNC:
 		case OP_LOADP_I:
+		case OP_STOREP_F:
+		case OP_STOREP_ENT:
+		case OP_STOREP_FLD:
+		case OP_STOREP_S:
+		case OP_STOREP_FNC:
+		case OP_STOREP_V:
+		case OP_STOREP_I:
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals || c >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d)", __func__, i);
 			prog->statements[i].op = op;
@@ -2448,28 +2458,14 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_NOT_ENT:
 			if (a >= prog->progs_numglobals || c >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d) in %s", __func__, i, prog->name);
+			if (b)
+				Con_DPrintf("%s: unexpected offset on binary opcode in %s\n", __func__, prog->name);
 			prog->statements[i].op = op;
 			prog->statements[i].operand[0] = remapglobal(a);
 			prog->statements[i].operand[1] = -1;
 			prog->statements[i].operand[2] = remapglobal(c);
 			break;
-		// 2 globals
-		case OP_STOREP_F:
-		case OP_STOREP_ENT:
-		case OP_STOREP_FLD:
-		case OP_STOREP_S:
-		case OP_STOREP_FNC:
-		case OP_STOREP_V:
-		case OP_STOREP_I:
-			if (c)	//Spike -- DP is alergic to pointers in QC. Try to avoid too many nasty surprises.
-				Con_DPrintf("%s: storep-with-offset is not permitted in %s\n", __func__, prog->name);
-			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals || c >= prog->progs_numglobals)
-				prog->error_cmd("%s: out of bounds global index (statement %d) in %s", __func__, i, prog->name);
-			prog->statements[i].op = op;
-			prog->statements[i].operand[0] = remapglobal(a);
-			prog->statements[i].operand[1] = remapglobal(b);
-			prog->statements[i].operand[2] = remapglobal(c);
-			break;
+		// global global none
 		case OP_STORE_F:
 		case OP_STORE_ENT:
 		case OP_STORE_FLD:
@@ -2481,6 +2477,8 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_STATE:
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d) in %s", __func__, i, prog->name);
+			if (c)
+				Con_DPrintf("%s: unexpected offset on binary opcode in %s\n", __func__, prog->name);
 			prog->statements[i].op = op;
 			prog->statements[i].operand[0] = remapglobal(a);
 			prog->statements[i].operand[1] = remapglobal(b);

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -1458,9 +1458,9 @@ qbool PRVM_ED_CallSpawnFunction(prvm_prog_t *prog, prvm_edict_t *ent, const char
 			}
 			else
 			{
-				
+
 				Con_DPrint("No spawn function for:\n");
-				if (developer.integer > 0) // don't confuse non-developers with errors	
+				if (developer.integer > 0) // don't confuse non-developers with errors
 					PRVM_ED_Print(prog, ent, NULL);
 
 				PRVM_ED_Free (prog, ent);
@@ -1567,7 +1567,7 @@ void PRVM_ED_LoadFromFile (prvm_prog_t *prog, const char *data)
 
 		if(!PRVM_ED_CallSpawnFunction(prog, ent, data, start))
 			continue;
-		
+
 		PRVM_ED_CallPostspawnFunction(prog, ent);
 
 		spawned++;
@@ -2445,17 +2445,23 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_STOREP_FLD:
 		case OP_STOREP_S:
 		case OP_STOREP_FNC:
+		case OP_STOREP_V:
 			if (c)	//Spike -- DP is alergic to pointers in QC. Try to avoid too many nasty surprises.
 				Con_DPrintf("%s: storep-with-offset is not permitted in %s\n", __func__, prog->name);
-			//fallthrough
+			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals || c >= prog->progs_numglobals)
+				prog->error_cmd("%s: out of bounds global index (statement %d) in %s", __func__, i, prog->name);
+			prog->statements[i].op = op;
+			prog->statements[i].operand[0] = remapglobal(a);
+			prog->statements[i].operand[1] = remapglobal(b);
+			prog->statements[i].operand[2] = remapglobal(c);
+			break;
 		case OP_STORE_F:
 		case OP_STORE_ENT:
 		case OP_STORE_FLD:
 		case OP_STORE_S:
 		case OP_STORE_FNC:
-		case OP_STATE:
-		case OP_STOREP_V:
 		case OP_STORE_V:
+		case OP_STATE:
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d) in %s", __func__, i, prog->name);
 			prog->statements[i].op = op;

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -2327,8 +2327,8 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_SUB_I:
 		case OP_SUB_FI:
 		case OP_SUB_IF:
-		case OP_CONV_IF:
-		case OP_CONV_FI:
+		case OP_CONV_ITOF:
+		case OP_CONV_FTOI:
 		case OP_LOAD_I:
 		case OP_BITAND_I:
 		case OP_BITOR_I:
@@ -2394,14 +2394,14 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_MUL_FV:
 		case OP_MUL_VF:
 		case OP_DIV_F:
-		case OP_BITAND:
-		case OP_BITOR:
-		case OP_GE:
-		case OP_LE:
-		case OP_GT:
-		case OP_LT:
-		case OP_AND:
-		case OP_OR:
+		case OP_BITAND_F:
+		case OP_BITOR_F:
+		case OP_GE_F:
+		case OP_LE_F:
+		case OP_GT_F:
+		case OP_LT_F:
+		case OP_AND_F:
+		case OP_OR_F:
 		case OP_EQ_F:
 		case OP_EQ_V:
 		case OP_EQ_S:

--- a/prvm_exec.c
+++ b/prvm_exec.c
@@ -860,7 +860,7 @@ static int PRVM_LeaveFunction (prvm_prog_t *prog)
 		f->tprofile_total += prog->stack[prog->depth].tprofile_acc;
 		f->builtinsprofile_total += prog->stack[prog->depth].builtinsprofile_acc;
 	}
-	
+
 	return prog->stack[prog->depth].s;
 }
 
@@ -922,6 +922,35 @@ extern cvar_t prvm_traceqc;
 extern cvar_t prvm_statementprofiling;
 extern qbool prvm_runawaycheck;
 
+#define PRVM_GLOBALSBASE 0x80000000
+
+// These do not change.
+#define CACHE_UNCHANGING() \
+	mstatement_t *cached_statements = prog->statements; \
+	qbool cached_allowworldwrites = prog->allowworldwrites; \
+	unsigned int cached_flag = prog->flag; \
+	unsigned int cached_vmglobals_1 = prog->numglobals - 1; \
+	unsigned int cached_vmglobals_3 = prog->numglobals - 3; \
+	unsigned int cached_vmglobalsstart = PRVM_GLOBALSBASE; \
+	unsigned int cached_vmglobal1 = cached_vmglobalsstart + 1; \
+	unsigned int cached_vmentity0start = cached_vmglobalsstart + prog->numglobals; \
+	unsigned int cached_vmentity1start = cached_vmentity0start + prog->entityfields; \
+	unsigned int cached_entityfields = prog->entityfields; \
+	unsigned int cached_entityfields_2 = prog->entityfields - 2; \
+	prvm_vec_t *globals = prog->globals.fp; \
+	prvm_vec_t *global1 = prog->globals.fp + 1
+
+// These may become out of date when a builtin is called, and are updated accordingly.
+#define CACHE_CHANGING(DECLARE) \
+	DECLARE(prvm_vec_t *) cached_edictsfields = prog->edictsfields.fp; \
+	DECLARE(prvm_vec_t *) cached_edictsfields_entity1 = cached_edictsfields + prog->entityfields; \
+	DECLARE(unsigned int) cached_entityfieldsarea_entityfields = prog->entityfieldsarea - prog->entityfields; \
+	DECLARE(unsigned int) cached_entityfieldsarea_entityfields_2 = prog->entityfieldsarea - prog->entityfields - 2; \
+	DECLARE(unsigned int) cached_max_edicts = prog->max_edicts
+
+#define DO_DECLARE(t) t
+#define NO_DECLARE(t)
+
 #ifdef PROFILING
 #ifdef CONFIG_MENU
 /*
@@ -940,21 +969,8 @@ void MVM_ExecuteProgram (prvm_prog_t *prog, func_t fnum, const char *errormessag
 	double  calltime;
 	double tm, starttm;
 	prvm_vec_t tempfloat;
-	// these may become out of date when a builtin is called, and are updated accordingly
-	prvm_vec_t *cached_edictsfields = prog->edictsfields.fp;
-	unsigned int cached_entityfields = prog->entityfields;
-	unsigned int cached_entityfields_3 = prog->entityfields - 3;
-	unsigned int cached_entityfieldsarea = prog->entityfieldsarea;
-	unsigned int cached_entityfieldsarea_entityfields = prog->entityfieldsarea - prog->entityfields;
-	unsigned int cached_entityfieldsarea_3 = prog->entityfieldsarea - 3;
-	unsigned int cached_entityfieldsarea_entityfields_3 = prog->entityfieldsarea - prog->entityfields - 3;
-	unsigned int cached_max_edicts = prog->max_edicts;
-	// these do not change
-	mstatement_t *cached_statements = prog->statements;
-	qbool cached_allowworldwrites = prog->allowworldwrites;
-	unsigned int cached_flag = prog->flag;
-
-	prvm_vec_t *globals = prog->globals.fp;
+	CACHE_UNCHANGING();
+	CACHE_CHANGING(DO_DECLARE);
 
 	calltime = Sys_DirtyTime();
 
@@ -1049,21 +1065,8 @@ void CLVM_ExecuteProgram (prvm_prog_t *prog, func_t fnum, const char *errormessa
 	double  calltime;
 	double tm, starttm;
 	prvm_vec_t tempfloat;
-	// these may become out of date when a builtin is called, and are updated accordingly
-	prvm_vec_t *cached_edictsfields = prog->edictsfields.fp;
-	unsigned int cached_entityfields = prog->entityfields;
-	unsigned int cached_entityfields_3 = prog->entityfields - 3;
-	unsigned int cached_entityfieldsarea = prog->entityfieldsarea;
-	unsigned int cached_entityfieldsarea_entityfields = prog->entityfieldsarea - prog->entityfields;
-	unsigned int cached_entityfieldsarea_3 = prog->entityfieldsarea - 3;
-	unsigned int cached_entityfieldsarea_entityfields_3 = prog->entityfieldsarea - prog->entityfields - 3;
-	unsigned int cached_max_edicts = prog->max_edicts;
-	// these do not change
-	mstatement_t *cached_statements = prog->statements;
-	qbool cached_allowworldwrites = prog->allowworldwrites;
-	unsigned int cached_flag = prog->flag;
-
-	prvm_vec_t *globals = prog->globals.fp;
+	CACHE_UNCHANGING();
+	CACHE_CHANGING(DO_DECLARE);
 
 	calltime = Sys_DirtyTime();
 
@@ -1162,21 +1165,8 @@ void PRVM_ExecuteProgram (prvm_prog_t *prog, func_t fnum, const char *errormessa
 	double  calltime;
 	double tm, starttm;
 	prvm_vec_t tempfloat;
-	// these may become out of date when a builtin is called, and are updated accordingly
-	prvm_vec_t *cached_edictsfields = prog->edictsfields.fp;
-	unsigned int cached_entityfields = prog->entityfields;
-	unsigned int cached_entityfields_3 = prog->entityfields - 3;
-	unsigned int cached_entityfieldsarea = prog->entityfieldsarea;
-	unsigned int cached_entityfieldsarea_entityfields = prog->entityfieldsarea - prog->entityfields;
-	unsigned int cached_entityfieldsarea_3 = prog->entityfieldsarea - 3;
-	unsigned int cached_entityfieldsarea_entityfields_3 = prog->entityfieldsarea - prog->entityfields - 3;
-	unsigned int cached_max_edicts = prog->max_edicts;
-	// these do not change
-	mstatement_t *cached_statements = prog->statements;
-	qbool cached_allowworldwrites = prog->allowworldwrites;
-	unsigned int cached_flag = prog->flag;
-
-	prvm_vec_t *globals = prog->globals.fp;
+	CACHE_UNCHANGING();
+	CACHE_CHANGING(DO_DECLARE);
 
 	calltime = Sys_DirtyTime();
 

--- a/prvm_exec.c
+++ b/prvm_exec.c
@@ -31,7 +31,7 @@ static const char *prvm_opnames[] =
 "MUL_V",
 "MUL_FV",
 "MUL_VF",
-"DIV",
+"DIV_F",
 "ADD_F",
 "ADD_V",
 "SUB_F",
@@ -54,12 +54,12 @@ static const char *prvm_opnames[] =
 "^2LT",
 "^2GT",
 
-"^6FIELD_F",
-"^6FIELD_V",
-"^6FIELD_S",
-"^6FIELD_ENT",
-"^6FIELD_FLD",
-"^6FIELD_FNC",
+"^6LOAD_F",
+"^6LOAD_V",
+"^6LOAD_S",
+"^6LOAD_ENT",
+"^6LOAD_FLD",
+"^6LOAD_FNC",
 
 "^1ADDRESS",
 
@@ -102,45 +102,59 @@ static const char *prvm_opnames[] =
 "BITAND",
 "BITOR",
 
+
+
+NULL,
+NULL,
+NULL,
+NULL,
+
+NULL,
+NULL,
+
+NULL,
+NULL,
+NULL,
+NULL,
+
+NULL,
+NULL,
+NULL,
+NULL,
+
+NULL,
+NULL,
+NULL,
+NULL,
+NULL,
+
+NULL,
+NULL,
+
+NULL,
+
+NULL,
+NULL,
+NULL,
+NULL,
+
 NULL,
 NULL,
 NULL,
 NULL,
 NULL,
 NULL,
+
 NULL,
 NULL,
 NULL,
 NULL,
 NULL,
+
 NULL,
 NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
+
+
 NULL,
 NULL,
 NULL,
@@ -151,7 +165,6 @@ NULL,
 NULL,
 
 "STORE_I",
-
 NULL,
 NULL,
 
@@ -162,15 +175,16 @@ NULL,
 "SUB_I",
 "SUB_FI",
 "SUB_IF",
+
 "CONV_IF",
 "CONV_FI",
 
 NULL,
 NULL,
 
-"^6FIELD_I",
-"^1STOREP_I",
+"^6LOAD_I",
 
+"^1STOREP_I",
 NULL,
 NULL,
 
@@ -183,6 +197,7 @@ NULL,
 "NE_I",
 
 NULL,
+
 NULL,
 
 "NOT_I",
@@ -195,6 +210,7 @@ NULL,
 
 "GLOBALADDRESS",
 "ADD_PIW",
+
 "LOADA_F",
 "LOADA_V",
 "LOADA_S",
@@ -240,9 +256,7 @@ NULL,
 "MUL_IF",
 "MUL_FI",
 "MUL_VI",
-
 NULL,
-
 "DIV_IF",
 "DIV_FI",
 "BITAND_IF",
@@ -273,10 +287,12 @@ NULL,
 "GLOAD_S",
 "GLOAD_FNC",
 "BOUNDCHECK",
+
 NULL,
 NULL,
 NULL,
 NULL,
+
 "GLOAD_V",
 };
 

--- a/prvm_exec.c
+++ b/prvm_exec.c
@@ -21,20 +21,19 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "quakedef.h"
 #include "progsvm.h"
 
+// Should only contain the opcodes DP actually implements, so unknown opcodes
+// are more readably marked as such in disassembly. Thus, best keep this in sync
+// with the list in prvm_execprogram.h.
 static const char *prvm_opnames[] =
 {
 "^5DONE",
-
 "MUL_F",
 "MUL_V",
 "MUL_FV",
 "MUL_VF",
-
 "DIV",
-
 "ADD_F",
 "ADD_V",
-
 "SUB_F",
 "SUB_V",
 
@@ -79,16 +78,13 @@ static const char *prvm_opnames[] =
 "^1STOREP_FNC",
 
 "^5RETURN",
-
 "^2NOT_F",
 "^2NOT_V",
 "^2NOT_S",
 "^2NOT_ENT",
 "^2NOT_FNC",
-
 "^5IF",
 "^5IFNOT",
-
 "^3CALL0",
 "^3CALL1",
 "^3CALL2",
@@ -98,19 +94,13 @@ static const char *prvm_opnames[] =
 "^3CALL6",
 "^3CALL7",
 "^3CALL8",
-
 "^1STATE",
-
 "^5GOTO",
-
 "^2AND",
 "^2OR",
 
 "BITAND",
 "BITOR",
-
-
-
 
 NULL,
 NULL,
@@ -178,8 +168,8 @@ NULL,
 NULL,
 NULL,
 
-"LOAD_I",
-"STOREP_I",
+"^6FIELD_I",
+"^1STOREP_I",
 
 NULL,
 NULL,
@@ -202,26 +192,27 @@ NULL,
 NULL,
 NULL,
 NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
+
+"GLOBALADDRESS",
+"ADD_PIW",
+"LOADA_F",
+"LOADA_V",
+"LOADA_S",
+"LOADA_ENT",
+"LOADA_FLD",
+"LOADA_FNC",
+"LOADA_I",
 
 "STORE_P",
+"^6FIELD_P",
 
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
-NULL,
+"LOADP_F",
+"LOADP_V",
+"LOADP_S",
+"LOADP_ENT",
+"LOADP_FLD",
+"LOADP_FNC",
+"LOADP_I",
 
 "LE_I",
 "GE_I",

--- a/prvm_exec.c
+++ b/prvm_exec.c
@@ -929,11 +929,12 @@ extern qbool prvm_runawaycheck;
 	mstatement_t *cached_statements = prog->statements; \
 	qbool cached_allowworldwrites = prog->allowworldwrites; \
 	unsigned int cached_flag = prog->flag; \
+	unsigned int cached_vmglobals = prog->numglobals; \
 	unsigned int cached_vmglobals_1 = prog->numglobals - 1; \
+	unsigned int cached_vmglobals_2 = prog->numglobals - 2; \
 	unsigned int cached_vmglobals_3 = prog->numglobals - 3; \
-	unsigned int cached_vmglobalsstart = PRVM_GLOBALSBASE; \
-	unsigned int cached_vmglobal1 = cached_vmglobalsstart + 1; \
-	unsigned int cached_vmentity0start = cached_vmglobalsstart + prog->numglobals; \
+	unsigned int cached_vmglobal1 = PRVM_GLOBALSBASE + 1; \
+	unsigned int cached_vmentity0start = PRVM_GLOBALSBASE + prog->numglobals; \
 	unsigned int cached_vmentity1start = cached_vmentity0start + prog->entityfields; \
 	unsigned int cached_entityfields = prog->entityfields; \
 	unsigned int cached_entityfields_2 = prog->entityfields - 2; \
@@ -944,6 +945,8 @@ extern qbool prvm_runawaycheck;
 #define CACHE_CHANGING(DECLARE) \
 	DECLARE(prvm_vec_t *) cached_edictsfields = prog->edictsfields.fp; \
 	DECLARE(prvm_vec_t *) cached_edictsfields_entity1 = cached_edictsfields + prog->entityfields; \
+	DECLARE(unsigned int) cached_entityfieldsarea = prog->entityfieldsarea; \
+	DECLARE(unsigned int) cached_entityfieldsarea_2 = prog->entityfieldsarea - 2; \
 	DECLARE(unsigned int) cached_entityfieldsarea_entityfields = prog->entityfieldsarea - prog->entityfields; \
 	DECLARE(unsigned int) cached_entityfieldsarea_entityfields_2 = prog->entityfieldsarea - prog->entityfields - 2; \
 	DECLARE(unsigned int) cached_max_edicts = prog->max_edicts

--- a/prvm_exec.c
+++ b/prvm_exec.c
@@ -49,10 +49,10 @@ static const char *prvm_opnames[] =
 "^2NE_E",
 "^2NE_FNC",
 
-"^2LE",
-"^2GE",
-"^2LT",
-"^2GT",
+"^2LE_F",
+"^2GE_F",
+"^2LT_F",
+"^2GT_F",
 
 "^6LOAD_F",
 "^6LOAD_V",
@@ -96,11 +96,11 @@ static const char *prvm_opnames[] =
 "^3CALL8",
 "^1STATE",
 "^5GOTO",
-"^2AND",
-"^2OR",
+"^2AND_F",
+"^2OR_F",
 
-"BITAND",
-"BITOR",
+"BITAND_F",
+"BITOR_F",
 
 
 
@@ -176,8 +176,8 @@ NULL,
 "SUB_FI",
 "SUB_IF",
 
-"CONV_IF",
-"CONV_FI",
+"CONV_ITOF",
+"CONV_FTOI",
 
 NULL,
 NULL,

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -1,6 +1,7 @@
 extern cvar_t prvm_garbagecollection_enable;
 int i;
-prvm_uint_t ofs, addr;
+prvm_uint_t addr, ofs;
+prvm_eval_t *src;
 // NEED to reset startst after calling this! startst may or may not be clobbered!
 #define ADVANCE_PROFILE_BEFORE_JUMP() \
 	prog->xfunction->profile += (st - startst); \
@@ -205,26 +206,26 @@ prvm_uint_t ofs, addr;
 	NULL,
 	NULL,
 	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
+	&&handle_OP_GLOBALADDRESS,
+	&&handle_OP_ADD_PIW,
+	&&handle_OP_LOADA_F,
+	&&handle_OP_LOADA_V,
+	&&handle_OP_LOADA_S,
+	&&handle_OP_LOADA_ENT,
+	&&handle_OP_LOADA_FLD,
+	&&handle_OP_LOADA_FNC,
+	&&handle_OP_LOADA_I,
 
 	&&handle_OP_STORE_P,
+	&&handle_OP_LOAD_P,
 
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
+	&&handle_OP_LOADP_F,
+	&&handle_OP_LOADP_V,
+	&&handle_OP_LOADP_S,
+	&&handle_OP_LOADP_ENT,
+	&&handle_OP_LOADP_FLD,
+	&&handle_OP_LOADP_FNC,
+	&&handle_OP_LOADP_I,
 
 	&&handle_OP_LE_I,
 	&&handle_OP_GE_I,
@@ -479,26 +480,26 @@ prvm_uint_t ofs, addr;
 			HANDLE_OPCODE(OP_STOREP_ENT):
 			HANDLE_OPCODE(OP_STOREP_FLD):		// integers
 			HANDLE_OPCODE(OP_STOREP_FNC):		// pointers
-				ofs = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
-				if ((addr = ofs - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
+				addr = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				if ((ofs = addr - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
 				{
 					// OK entity write.
-					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + addr);
+					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + ofs);
 				}
-				else if ((addr = ofs - cached_vmglobal1) < cached_vmglobals_1)
+				else if ((ofs = addr - cached_vmglobal1) < cached_vmglobals_1)
 				{
 					// OK global write.
-					ptr = (prvm_eval_t *)(global1 + addr);
+					ptr = (prvm_eval_t *)(global1 + ofs);
 				}
-				else if ((addr = ofs - cached_vmentity0start) < cached_entityfields)
+				else if ((ofs = addr - cached_vmentity0start) < cached_entityfields)
 				{
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, addr)->s_name), OPB->_int, OPC->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
-					ptr = (prvm_eval_t *)(cached_edictsfields + addr);
+					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
 				}
 				else
 				{
@@ -509,26 +510,26 @@ prvm_uint_t ofs, addr;
 				ptr->_int = OPA->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_STOREP_S):
-				ofs = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
-				if ((addr = ofs - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
+				addr = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				if ((ofs = addr - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
 				{
 					// OK entity write.
-					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + addr);
+					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + ofs);
 				}
-				else if ((addr = ofs - cached_vmglobal1) < cached_vmglobals_1)
+				else if ((ofs = addr - cached_vmglobal1) < cached_vmglobals_1)
 				{
 					// OK global write.
-					ptr = (prvm_eval_t *)(global1 + addr);
+					ptr = (prvm_eval_t *)(global1 + ofs);
 				}
-				else if ((addr = ofs - cached_vmentity0start) < cached_entityfields)
+				else if ((ofs = addr - cached_vmentity0start) < cached_entityfields)
 				{
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, addr)->s_name), OPB->_int, OPC->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
-					ptr = (prvm_eval_t *)(cached_edictsfields + addr);
+					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
 				}
 				else
 				{
@@ -545,26 +546,26 @@ prvm_uint_t ofs, addr;
 				ptr->_int = OPA->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_STOREP_V):
-				ofs = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
-				if ((addr = ofs - cached_vmentity1start) < cached_entityfieldsarea_entityfields_2)
+				addr = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				if ((ofs = addr - cached_vmentity1start) < cached_entityfieldsarea_entityfields_2)
 				{
 					// OK entity write.
-					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + addr);
+					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + ofs);
 				}
-				else if ((addr = ofs - cached_vmglobal1) < cached_vmglobals_3)
+				else if ((ofs = addr - cached_vmglobal1) < cached_vmglobals_3)
 				{
 					// OK global write.
-					ptr = (prvm_eval_t *)(global1 + addr);
+					ptr = (prvm_eval_t *)(global1 + ofs);
 				}
-				else if ((addr = ofs - cached_vmentity0start) < cached_entityfields_2)
+				else if ((ofs = addr - cached_vmentity0start) < cached_entityfields_2)
 				{
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, addr)->s_name), OPB->_int, OPC->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
-					ptr = (prvm_eval_t *)(cached_edictsfields + addr);
+					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
 				}
 				else
 				{
@@ -605,6 +606,7 @@ prvm_uint_t ofs, addr;
 			HANDLE_OPCODE(OP_LOAD_FLD):
 			HANDLE_OPCODE(OP_LOAD_ENT):
 			HANDLE_OPCODE(OP_LOAD_FNC):
+			HANDLE_OPCODE(OP_LOAD_P):
 				if ((prvm_uint_t)OPA->edict >= cached_max_edicts)
 				{
 					PRE_ERROR();
@@ -1075,6 +1077,127 @@ prvm_uint_t ofs, addr;
 					prog->error_cmd("Progs boundcheck failed in %s, value is < %" PRVM_PRIi " or >= %" PRVM_PRIi, prog->name, OPC->_int, OPB->_int);
 					goto cleanup;
 				}
+				DISPATCH_OPCODE();
+
+			// FTEQW pointer instructions.
+			HANDLE_OPCODE(OP_GLOBALADDRESS):
+				OPC->_int = PRVM_GLOBALSBASE + st->operand[0] + 1 * OPB->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_ADD_PIW):
+				OPC->_int = OPA->_int + 1 * OPB->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LOADA_F):
+			HANDLE_OPCODE(OP_LOADA_ENT):
+			HANDLE_OPCODE(OP_LOADA_FLD):
+			HANDLE_OPCODE(OP_LOADA_FNC):
+			HANDLE_OPCODE(OP_LOADA_I):
+				ofs = st->operand[0] + OPB->_int;
+				if (ofs >= cached_vmglobals)
+				{
+					PRE_ERROR();
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)st->operand[0], OPB->_int);
+					goto cleanup;
+				}
+				src = (prvm_eval_t *)&globals[ofs];
+				OPC->_int = src->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LOADA_S):
+				ofs = st->operand[0] + OPB->_int;
+				if (ofs >= cached_vmglobals)
+				{
+					PRE_ERROR();
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)st->operand[0], OPB->_int);
+					goto cleanup;
+				}
+				src = (prvm_eval_t *)&globals[ofs];
+				// refresh the garbage collection on the string - this guards
+				// against a certain sort of repeated migration to earlier
+				// points in the scan that could otherwise result in the string
+				// being freed for being unused
+				if(prvm_garbagecollection_enable.integer)
+					PRVM_GetString(prog, src->_int);
+				OPC->_int = src->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LOADA_V):
+				ofs = st->operand[0] + OPB->_int;
+				if (ofs >= cached_vmglobals_2)
+				{
+					PRE_ERROR();
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)st->operand[0], OPB->_int);
+					goto cleanup;
+				}
+				src = (prvm_eval_t *)&globals[ofs];
+				OPC->ivector[0] = src->ivector[0];
+				OPC->ivector[1] = src->ivector[1];
+				OPC->ivector[2] = src->ivector[2];
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LOADP_F):
+			HANDLE_OPCODE(OP_LOADP_ENT):
+			HANDLE_OPCODE(OP_LOADP_FLD):		// integers
+			HANDLE_OPCODE(OP_LOADP_FNC):		// pointers
+			HANDLE_OPCODE(OP_LOADP_I):
+				addr = (prvm_uint_t)OPA->_int + (prvm_uint_t)OPB->_int;
+				if ((ofs = addr - cached_vmentity0start) < cached_entityfieldsarea)
+				{
+					// OK entity write.
+					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
+				}
+				else if ((ofs = addr - PRVM_GLOBALSBASE) < cached_vmglobals)
+				{
+					// OK global write.
+					ptr = (prvm_eval_t *)(globals + ofs);
+				}
+				else
+				{
+					PRE_ERROR();
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)OPA->_int, OPB->_int);
+					goto cleanup;
+				}
+				OPC->_int = ptr->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LOADP_S):
+				addr = (prvm_uint_t)OPA->_int + (prvm_uint_t)OPB->_int;
+				if ((ofs = addr - cached_vmentity0start) < cached_entityfieldsarea)
+				{
+					// OK entity write.
+					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
+				}
+				else if ((ofs = addr - PRVM_GLOBALSBASE) < cached_vmglobals)
+				{
+					// OK global write.
+					ptr = (prvm_eval_t *)(globals + ofs);
+				}
+				else
+				{
+					PRE_ERROR();
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)OPA->_int, OPB->_int);
+					goto cleanup;
+				}
+				if(prvm_garbagecollection_enable.integer)
+					PRVM_GetString(prog, ptr->_int);
+				OPC->_int = ptr->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LOADP_V):
+				addr = (prvm_uint_t)OPA->_int + (prvm_uint_t)OPB->_int;
+				if ((ofs = addr - cached_vmentity0start) < cached_entityfieldsarea_2)
+				{
+					// OK entity write.
+					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
+				}
+				else if ((ofs = addr - PRVM_GLOBALSBASE) < cached_vmglobals_2)
+				{
+					// OK global write.
+					ptr = (prvm_eval_t *)(globals + ofs);
+				}
+				else
+				{
+					PRE_ERROR();
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)OPA->_int, OPB->_int);
+					goto cleanup;
+				}
+				OPC->ivector[0] = ptr->ivector[0];
+				OPC->ivector[1] = ptr->ivector[1];
+				OPC->ivector[2] = ptr->ivector[2];
 				DISPATCH_OPCODE();
 
 #if !USE_COMPUTED_GOTOS

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -1,6 +1,6 @@
 extern cvar_t prvm_garbagecollection_enable;
 int i;
-prvm_uint_t addr;
+prvm_uint_t ofs, addr;
 // NEED to reset startst after calling this! startst may or may not be clobbered!
 #define ADVANCE_PROFILE_BEFORE_JUMP() \
 	prog->xfunction->profile += (st - startst); \
@@ -479,59 +479,61 @@ prvm_uint_t addr;
 			HANDLE_OPCODE(OP_STOREP_ENT):
 			HANDLE_OPCODE(OP_STOREP_FLD):		// integers
 			HANDLE_OPCODE(OP_STOREP_FNC):		// pointers
-				if ((addr = (prvm_uint_t)OPB->_int - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
+				ofs = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				if ((addr = ofs - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
 				{
 					// OK entity write.
 					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + addr);
 				}
-				else if ((addr = (prvm_uint_t)OPB->_int - cached_vmglobal1) < cached_vmglobals_1)
+				else if ((addr = ofs - cached_vmglobal1) < cached_vmglobals_1)
 				{
 					// OK global write.
 					ptr = (prvm_eval_t *)(global1 + addr);
 				}
-				else if ((prvm_uint_t)OPB->_int - cached_vmentity0start < cached_entityfields)
+				else if ((addr = ofs - cached_vmentity0start) < cached_entityfields)
 				{
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, OPB->_int)->s_name), (int)OPB->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, addr)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
-					ptr = (prvm_eval_t *)(cached_edictsfields + OPB->_int);
+					ptr = (prvm_eval_t *)(cached_edictsfields + addr);
 				}
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to write to an out of bounds edict (%i)", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to write to an out of bounds address %u+%i", prog->name, (unsigned int)OPB->_int, OPC->_int);
 					goto cleanup;
 				}
 				ptr->_int = OPA->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_STOREP_S):
-				if ((addr = (prvm_uint_t)OPB->_int - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
+				ofs = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				if ((addr = ofs - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
 				{
 					// OK entity write.
 					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + addr);
 				}
-				else if ((addr = (prvm_uint_t)OPB->_int - cached_vmglobal1) < cached_vmglobals_1)
+				else if ((addr = ofs - cached_vmglobal1) < cached_vmglobals_1)
 				{
 					// OK global write.
 					ptr = (prvm_eval_t *)(global1 + addr);
 				}
-				else if ((prvm_uint_t)OPB->_int - cached_vmentity0start < cached_entityfields)
+				else if ((addr = ofs - cached_vmentity0start) < cached_entityfields)
 				{
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, OPB->_int)->s_name), (int)OPB->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, addr)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
-					ptr = (prvm_eval_t *)(cached_edictsfields + OPB->_int);
+					ptr = (prvm_eval_t *)(cached_edictsfields + addr);
 				}
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to write to an out of bounds edict (%i)", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to write to an out of bounds address %u+%i", prog->name, (unsigned int)OPB->_int, OPC->_int);
 					goto cleanup;
 				}
 				// refresh the garbage collection on the string - this guards
@@ -543,30 +545,31 @@ prvm_uint_t addr;
 				ptr->_int = OPA->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_STOREP_V):
-				if ((addr = (prvm_uint_t)OPB->_int - cached_vmentity1start) < cached_entityfieldsarea_entityfields_2)
+				ofs = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				if ((addr = ofs - cached_vmentity1start) < cached_entityfieldsarea_entityfields_2)
 				{
 					// OK entity write.
 					ptr = (prvm_eval_t *)(cached_edictsfields_entity1 + addr);
 				}
-				else if ((addr = (prvm_uint_t)OPB->_int - cached_vmglobal1) < cached_vmglobals_3)
+				else if ((addr = ofs - cached_vmglobal1) < cached_vmglobals_3)
 				{
 					// OK global write.
-					ptr = (prvm_eval_t *)(global1 + OPB->_int);
+					ptr = (prvm_eval_t *)(global1 + addr);
 				}
-				else if ((prvm_uint_t)OPB->_int - cached_vmentity0start < cached_entityfields_2)
+				else if ((addr = ofs - cached_vmentity0start) < cached_entityfields_2)
 				{
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, OPB->_int)->s_name), (int)OPB->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, addr)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
-					ptr = (prvm_eval_t *)(cached_edictsfields + OPB->_int);
+					ptr = (prvm_eval_t *)(cached_edictsfields + addr);
 				}
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to write to an out of bounds edict (%i)", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to write to an out of bounds address %u+%i", prog->name, (unsigned int)OPB->_int, OPC->_int);
 					goto cleanup;
 				}
 				ptr->ivector[0] = OPA->ivector[0];

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -206,6 +206,7 @@ prvm_eval_t *src;
 	NULL,
 	NULL,
 	NULL,
+
 	&&handle_OP_GLOBALADDRESS,
 	&&handle_OP_ADD_PIW,
 	&&handle_OP_LOADA_F,

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -63,10 +63,10 @@ prvm_eval_t *src;
 	&&handle_OP_NE_E,
 	&&handle_OP_NE_FNC,
 
-	&&handle_OP_LE,
-	&&handle_OP_GE,
-	&&handle_OP_LT,
-	&&handle_OP_GT,
+	&&handle_OP_LE_F,
+	&&handle_OP_GE_F,
+	&&handle_OP_LT_F,
+	&&handle_OP_GT_F,
 
 	&&handle_OP_LOAD_F,
 	&&handle_OP_LOAD_V,
@@ -110,11 +110,11 @@ prvm_eval_t *src;
 	&&handle_OP_CALL8,
 	&&handle_OP_STATE,
 	&&handle_OP_GOTO,
-	&&handle_OP_AND,
-	&&handle_OP_OR,
+	&&handle_OP_AND_F,
+	&&handle_OP_OR_F,
 
-	&&handle_OP_BITAND,
-	&&handle_OP_BITOR,
+	&&handle_OP_BITAND_F,
+	&&handle_OP_BITOR_F,
 
 	NULL,
 	NULL,
@@ -176,8 +176,8 @@ prvm_eval_t *src;
 	&&handle_OP_SUB_I,
 	&&handle_OP_SUB_FI,
 	&&handle_OP_SUB_IF,
-	&&handle_OP_CONV_IF,
-	&&handle_OP_CONV_FI,
+	&&handle_OP_CONV_ITOF,
+	&&handle_OP_CONV_FTOI,
 
 	NULL,
 	NULL,
@@ -385,28 +385,28 @@ prvm_eval_t *src;
 					OPC->_float = 0.0f;
 				}
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_BITAND):
+			HANDLE_OPCODE(OP_BITAND_F):
 				OPC->_float = (prvm_int_t)OPA->_float & (prvm_int_t)OPB->_float;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_BITOR):
+			HANDLE_OPCODE(OP_BITOR_F):
 				OPC->_float = (prvm_int_t)OPA->_float | (prvm_int_t)OPB->_float;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_GE):
+			HANDLE_OPCODE(OP_GE_F):
 				OPC->_float = OPA->_float >= OPB->_float;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_LE):
+			HANDLE_OPCODE(OP_LE_F):
 				OPC->_float = OPA->_float <= OPB->_float;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_GT):
+			HANDLE_OPCODE(OP_GT_F):
 				OPC->_float = OPA->_float > OPB->_float;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_LT):
+			HANDLE_OPCODE(OP_LT_F):
 				OPC->_float = OPA->_float < OPB->_float;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_AND):
+			HANDLE_OPCODE(OP_AND_F):
 				OPC->_float = PRVM_FLOAT_IS_TRUE_FOR_INT(OPA->_int) && PRVM_FLOAT_IS_TRUE_FOR_INT(OPB->_int); // TODO change this back to float, and add AND_I to be used by fteqcc for anything not a float
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_OR):
+			HANDLE_OPCODE(OP_OR_F):
 				OPC->_float = PRVM_FLOAT_IS_TRUE_FOR_INT(OPA->_int) || PRVM_FLOAT_IS_TRUE_FOR_INT(OPB->_int); // TODO change this back to float, and add OR_I to be used by fteqcc for anything not a float
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_NOT_F):
@@ -691,6 +691,13 @@ prvm_eval_t *src;
 
 			HANDLE_OPCODE(OP_IF):
 				//spike FIXME -- dp redefined IF[_I] as IF_F
+				// TODO: plan is:
+				// - Add IF_F, IFNOT_F.
+				// - Rename this to IF_I, IFNOT_I.
+				// - Add sv_gameplayfix variable to remap IF_I and IFNOT_I to IF_F and IFNOT_F on progs load.
+				// - Define this fix for Nexuiz.
+				// - Add generation of IF_F, IFNOT_F instructions to gmqcc.
+				// - Move Xonotic to that.
 				if(FLOAT_IS_TRUE_FOR_INT(OPA->_int))
 				// TODO add an "int-if", and change this one, as well as the FLOAT_IS_TRUE_FOR_INT usages, to OPA->_float
 				// although mostly unneeded, thanks to the only float being false being 0x0 and 0x80000000 (negative zero)
@@ -873,10 +880,10 @@ prvm_eval_t *src;
 			HANDLE_OPCODE(OP_DIV_FI):
 				OPC->_float = OPA->_float / (prvm_vec_t) OPB->_int;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_CONV_IF):
+			HANDLE_OPCODE(OP_CONV_ITOF):
 				OPC->_float = OPA->_int;
 				DISPATCH_OPCODE();
-			HANDLE_OPCODE(OP_CONV_FI):
+			HANDLE_OPCODE(OP_CONV_FTOI):
 				OPC->_int = OPA->_float;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_BITAND_I):

--- a/sv_main.c
+++ b/sv_main.c
@@ -1195,7 +1195,7 @@ static void Download_CheckExtensions(cmd_state_t *cmd)
 
 	// first reset them all
 	host_client->download_deflate = false;
-	
+
 	for(i = 2; i < argc; ++i)
 	{
 		if(!strcmp(Cmd_Argv(cmd, i), "deflate"))
@@ -1239,7 +1239,7 @@ static void SV_Download_f(cmd_state_t *cmd)
 	}
 
 	is_csqc = (sv.csqc_progname[0] && strcmp(Cmd_Argv(cmd, 1), sv.csqc_progname) == 0);
-	
+
 	if (!sv_allowdownloads.integer && !is_csqc)
 	{
 		SV_ClientPrintf("Downloads are disabled on this server\n");
@@ -1260,17 +1260,17 @@ static void SV_Download_f(cmd_state_t *cmd)
 	{
 		char extensions[MAX_QPATH]; // make sure this can hold all extensions
 		extensions[0] = '\0';
-		
+
 		if(host_client->download_deflate)
 			dp_strlcat(extensions, " deflate", sizeof(extensions));
-		
+
 		Con_DPrintf("Downloading %s to %s\n", host_client->download_name, host_client->name);
 
 		if(host_client->download_deflate && svs.csqc_progdata_deflated)
 			host_client->download_file = FS_FileFromData(svs.csqc_progdata_deflated, svs.csqc_progsize_deflated, true);
 		else
 			host_client->download_file = FS_FileFromData(svs.csqc_progdata, sv.csqc_progsize, true);
-		
+
 		// no, no space is needed between %s and %s :P
 		SV_ClientCommands("\ncl_downloadbegin %i %s%s\n", (int)FS_FileSize(host_client->download_file), host_client->download_name, extensions);
 
@@ -1373,7 +1373,7 @@ static void SV_Download_f(cmd_state_t *cmd)
 	{
 		char extensions[MAX_QPATH]; // make sure this can hold all extensions
 		extensions[0] = '\0';
-		
+
 		if(host_client->download_deflate)
 			strlcat(extensions, " deflate", sizeof(extensions));
 
@@ -1723,7 +1723,7 @@ static void SV_Prepare_CSQC(void)
 
 	svs.csqc_progdata = NULL;
 	svs.csqc_progdata_deflated = NULL;
-	
+
 	sv.csqc_progname[0] = 0;
 	svs.csqc_progdata = FS_LoadFile(csqc_progname.string, sv_mempool, false, &progsize);
 
@@ -2651,7 +2651,7 @@ double SV_Frame(double time)
 			++sv.perf_acc_offset_samples;
 			sv.perf_acc_offset += offset;
 			sv.perf_acc_offset_squared += offset * offset;
-			
+
 			if(sv.perf_acc_offset_max < offset)
 				sv.perf_acc_offset_max = offset;
 		}


### PR DESCRIPTION
This adds the following instructions:

* GLOBALADDRESS
* ADD_PIW
* LOADA_{F,V,S,ENT,FLD,FNC,I}
* LOAD_P
* LOADP_{F,V,S,ENT,FLD,FNC,I}
* Offset feature, and support for global pointers, for STOREP_{F,V,S,ENT,FLD,FNC,I}

It changes QC "address space" as follows:

* Before:
  * [0x0, num_ents * num_fields[: entities
* After:
  * [0x0, 0x80000000[: reserved (FTE puts strings and "malloc area" there)
  * [0x80000000, 0x80000000 + num_globals[: globals
  * [0x80000000 + num_globals, 0x80000000 + num_globals + num_ents * num_fields[: entities

This changes nothing visible, as these pointer values are generally invisible to well written QC code, however, writing to a NULL pointer notably now errors in the QC VM (previously, it would overwrite `world.modelindex`, which, I guess, may make the map go away, doesn't do that for me though).

Tested: this speeds up Xonotic serverbench by 6.8% while keeping correctness:

* Before/GMQCC: real 44.68 user 43.77 progs.dat size 6892660
* Before/FTEQCC: real 43.35 user 42.53 progs.dat size 6774526
* This/FTEQCC: real 41.87 user 40.96 progs.dat size 6436758