### PR TITLE
Invert the supercontents test when setting skynoshadowtexture on sky surfaces

### DIFF
--- a/model_brush.c
+++ b/model_brush.c
@@ -3275,7 +3275,7 @@ static void Mod_Q1BSP_AssignNoShadowSkySurfaces(model_t *mod)
 			// check if the point behind the surface polygon is SOLID or SKY contents
 			VectorMAMAM(0.5f, surface->mins, 0.5f, surface->maxs, -0.25f, mod->surfmesh.data_normal3f + 3*surface->num_firstvertex, center);
 			contents = Mod_Q1BSP_PointSuperContents(mod, 0, center);
-			if (!(contents & SUPERCONTENTS_SOLID))
+			if (contents & SUPERCONTENTS_SOLID)
 				surface->texture = surface->texture->skynoshadowtexture;
 		}
 	}


### PR DESCRIPTION
Inverts the contents test in `Mod_Q1BSP_AssignNoShadowSkySurfaces` when determining whether or not to set `skynoshadowtexture` on a sky surface. This now means that sky surfaces touching the void will block rtlights, but other sky surfaces, like that in e1m5, will not.

Fixes #220 