### PR TITLE
Simplify decal system.

### DIFF
--- a/client.h
+++ b/client.h
@@ -57,7 +57,6 @@ typedef struct decalsystem_s
 	model_t *model;
 	double lastupdatetime;
 	int maxdecals;
-	int freedecal;
 	int numdecals;
 	tridecal_t *decals;
 	float *vertex3f;


### PR DESCRIPTION
Removes the `freedecal` field, and as such, fixes some invariant violations found in issue #216 that appear to lead to engine crashes.

Performance should remain unchanged, as the decal expiry process performed full decal copies from end spots to unoccupied spots as part of its "shuffling" loop anyway. New decals are now always added to the end, and when a decal expires, it's now always replaced by the current last decal in the list. If only one decal were to expire per frame, this matches the previous behavior, so I am not expecting any visible differences due to decal Z index in regular gameplay from this either.

Fixes issue #216.