### PR TITLE
Prevent VM_rint outputting negative zero

### DIFF
--- a/prvm_cmds.c
+++ b/prvm_cmds.c
@@ -1511,13 +1511,12 @@ void VM_rint(prvm_prog_t *prog)
 	VM_SAFEPARMCOUNT(1,VM_rint);
 
 	f = PRVM_G_FLOAT(OFS_PARM0);
-	if (f >= 0)
+	if (f >= 0.5) // >= 0 works too, but would be slightly less optimized 
 		PRVM_G_FLOAT(OFS_RETURN) = floor(f + 0.5);
+	else if (f > -0.5)
+		PRVM_G_FLOAT(OFS_RETURN) = 0; // prevents negative 0
 	else
-	{
-		f = ceil(f - 0.5);
-		PRVM_G_FLOAT(OFS_RETURN) = f == -0.0 ? 0.0 : f;
-	}
+		PRVM_G_FLOAT(OFS_RETURN) = ceil(f - 0.5);
 }
 
 /*


### PR DESCRIPTION
As the name suggests, `VM_rint` rounding to an int should output a value that can actually be represented by an int, which negative zero can't.
Previously values from -0.5 to 0.0, including +0, -0, and not -0.5, would round to -0. This meant rounding a value known to be non-negative could output negative zero. This function now outputs +0 for the aforementioned values.

If for whatever reason it's actually intentional that it can sometimes output -0, I'd suggest changing the diff to be just the following (below), so that at least `VM_rint(0.0) == 0.0`, rather than `VM_rint(0.0) == -0.0`. It'd then be functionally identical to C's `round` function as far as I can tell.
```diff
-	if (f > 0)
+	if (f >= 0)
```

Haven't tested the code, unable to, reviewer please do so.