### PR TITLE
Remove Python installation from wasm-release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:23.10
+      image: debian:latest
     steps:
       - name: Install dependencies
         run: |
@@ -75,7 +75,7 @@ jobs:
           cd emsdk
 
           # Download and install the latest SDK tools.
-          ./emsdk install latest
+          ./emsdk install 2.0.34
 
           # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
           ./emsdk activate latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Install emsdk
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: debian:latest
+      image: debian:bullseye
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:20.04
+      image: ubuntu:22.04
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
   pull_request:
-  workflow_dispatch:
 
 jobs:
   sdl-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,9 +59,9 @@ jobs:
           # make `git describe` show the correct commit hash
           fetch-depth: '0'
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      # - uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.10'
 
       - name: Install emsdk
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: debian:bullseye
+      image: debian:latest
     steps:
       - name: Install dependencies
         run: |
@@ -75,7 +75,7 @@ jobs:
           cd emsdk
 
           # Download and install the latest SDK tools.
-          ./emsdk install 2.0.34
+          ./emsdk install latest-upstream
 
           # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
           ./emsdk activate latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   sdl-release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,39 +9,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  sdl-release:
-    runs-on: ubuntu-latest
-    container:
-      image: debian:latest
-    steps:
-      # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
-      - name: Install dependencies
-        run: |
-          apt update
-          apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
+  # sdl-release:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: debian:latest
+  #   steps:
+  #     # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
+  #     - name: Install dependencies
+  #       run: |
+  #         apt update
+  #         apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
 
-      - name: Fetch repository
-        uses: actions/checkout@v4.1.1
-        with:
-          # make `git describe` show the correct commit hash
-          fetch-depth: '0'
+  #     - name: Fetch repository
+  #       uses: actions/checkout@v4.1.1
+  #       with:
+  #         # make `git describe` show the correct commit hash
+  #         fetch-depth: '0'
 
-      - name: Compile
-        run: |
-          # prevent git complaining about dubious ownership of the repo
-          chown -R root:root .
-          # fail if `git describe` doesn't work (required for the buildstring)
-          git describe --always
-          # fail if there's any warnings
-          export CC="cc -Werror"
-          make sdl-release
+  #     - name: Compile
+  #       run: |
+  #         # prevent git complaining about dubious ownership of the repo
+  #         chown -R root:root .
+  #         # fail if `git describe` doesn't work (required for the buildstring)
+  #         git describe --always
+  #         # fail if there's any warnings
+  #         export CC="cc -Werror"
+  #         make sdl-release
 
-      - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Linux
-          path: |
-            darkplaces-sdl
+  #     - name: Upload Linux artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: Linux
+  #         path: |
+  #           darkplaces-sdl
 
   wasm-release:
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3'
+          python-version: '3.11'
 
       - name: Install emsdk
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: debian:latest
     steps:
       - name: Install dependencies
         run: |
@@ -58,10 +58,6 @@ jobs:
         with:
           # make `git describe` show the correct commit hash
           fetch-depth: '0'
-
-      # - uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.10'
 
       - name: Install emsdk
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: debian:latest
+      image: ubuntu:22.04
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           cd emsdk
 
           # Download and install the latest SDK tools.
-          ./emsdk install 3.1.65
+          ./emsdk install latest
 
           # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
           ./emsdk activate latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,39 +9,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  # sdl-release:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: debian:latest
-  #   steps:
-  #     # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
-  #     - name: Install dependencies
-  #       run: |
-  #         apt update
-  #         apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
+  sdl-release:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:latest
+    steps:
+      # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
+      - name: Install dependencies
+        run: |
+          apt update
+          apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
 
-  #     - name: Fetch repository
-  #       uses: actions/checkout@v4.1.1
-  #       with:
-  #         # make `git describe` show the correct commit hash
-  #         fetch-depth: '0'
+      - name: Fetch repository
+        uses: actions/checkout@v4.1.1
+        with:
+          # make `git describe` show the correct commit hash
+          fetch-depth: '0'
 
-  #     - name: Compile
-  #       run: |
-  #         # prevent git complaining about dubious ownership of the repo
-  #         chown -R root:root .
-  #         # fail if `git describe` doesn't work (required for the buildstring)
-  #         git describe --always
-  #         # fail if there's any warnings
-  #         export CC="cc -Werror"
-  #         make sdl-release
+      - name: Compile
+        run: |
+          # prevent git complaining about dubious ownership of the repo
+          chown -R root:root .
+          # fail if `git describe` doesn't work (required for the buildstring)
+          git describe --always
+          # fail if there's any warnings
+          export CC="cc -Werror"
+          make sdl-release
 
-  #     - name: Upload Linux artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: Linux
-  #         path: |
-  #           darkplaces-sdl
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Linux
+          path: |
+            darkplaces-sdl
 
   wasm-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: ubuntu:23.10
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
   wasm-release:
     runs-on: ubuntu-latest
     container:
-      image: debian:latest
+      image: ubuntu:20.04
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           cd emsdk
 
           # Download and install the latest SDK tools.
-          ./emsdk install latest-upstream
+          ./emsdk install 3.1.65
 
           # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
           ./emsdk activate latest


### PR DESCRIPTION
Remove the Python installation step from the wasm-release pipeline job so that it can actually get to the engine compilation.