### PR TITLE
Update registercvar definitions in dpdefs to allow additional parameters

### DIFF
--- a/dpdefs/csprogsdefs.qc
+++ b/dpdefs/csprogsdefs.qc
@@ -419,7 +419,7 @@ const float LP_RTWORLD = 2;
 const float LP_DYNLIGHT = 4;
 const float LP_COMPLETE = 7;
 
-float(string name, string value) registercvar = #93;
+float(string name, string value, ...) registercvar = #93;
 float( float a, ... ) min = #94;
 float( float b, ... ) max = #95;
 float(float minimum, float val, float maximum) bound = #96;

--- a/dpdefs/dpextensions.qc
+++ b/dpdefs/dpextensions.qc
@@ -1257,7 +1257,7 @@ float(string url, float id, string content_type, string delim, float buf) uri_po
 //idea: LadyHavoc
 //darkplaces implementation: LadyHavoc
 //builtin definitions:
-float(string name, string value) registercvar = #93;
+float(string name, string value, ...) registercvar = #93;
 //description:
 //adds a new console cvar to the server console (in singleplayer this is the player's console), the cvar exists until the mod is unloaded or the game quits.
 //NOTE: DP_CON_SET is much better.


### PR DESCRIPTION
The `registercvar` builtin optionally supports a 3rd parameter:  
`flags = prog->argc >= 3 ? (int)PRVM_G_FLOAT(OFS_PARM2) : 0;`

This change updates the dpdefs for CSQC and SVQC (menu already included the additional parameter) to match, making registered cvar flags accessible to the other VMs.