### PR TITLE
Implement a set of new QC opcodes for bit shifts and unsigned integer math.

### DIFF
--- a/progsvm.h
+++ b/progsvm.h
@@ -65,6 +65,7 @@ typedef union prvm_eval_s
 	prvm_int_t		function;
 	prvm_int_t		ivector[3];
 	prvm_int_t		_int;
+	prvm_uint_t		_uint;
 	prvm_int_t		edict;
 } prvm_eval_t;
 

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -2443,6 +2443,12 @@ void PRVM_Prog_Load(prvm_prog_t *prog, const char *filename, unsigned char *data
 		case OP_STOREP_FNC:
 		case OP_STOREP_V:
 		case OP_STOREP_I:
+		case OP_RSHIFT_I:
+		case OP_LSHIFT_I:
+		case OP_LE_U:
+		case OP_LT_U:
+		case OP_DIV_U:
+		case OP_RSHIFT_U:
 			if (a >= prog->progs_numglobals || b >= prog->progs_numglobals || c >= prog->progs_numglobals)
 				prog->error_cmd("%s: out of bounds global index (statement %d)", __func__, i);
 			prog->statements[i].op = op;

--- a/prvm_exec.c
+++ b/prvm_exec.c
@@ -205,8 +205,8 @@ NULL,
 "DIV_VF",
 
 NULL,
-NULL,
-NULL,
+"RSHIFT_I",
+"LSHIFT_I",
 
 "GLOBALADDRESS",
 "ADD_PIW",
@@ -294,6 +294,24 @@ NULL,
 NULL,
 
 "GLOAD_V",
+
+NULL,
+NULL,
+
+NULL,
+NULL,
+NULL,
+NULL,
+
+
+NULL,
+NULL,
+
+
+"^2LE_U",
+"^2LT_U",
+"DIV_U",
+"RSHIFT_U",
 };
 
 

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -835,7 +835,7 @@ prvm_eval_t *src;
 				OPC->_int = OPA->_int + OPB->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_ADD_IF):
-				OPC->_float = OPA->_int + (prvm_int_t) OPB->_float;
+				OPC->_float = ((prvm_vec_t) OPA->_int) + OPB->_float;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_ADD_FI):
 				OPC->_float = OPA->_float + (prvm_vec_t) OPB->_int;
@@ -844,7 +844,7 @@ prvm_eval_t *src;
 				OPC->_int = OPA->_int - OPB->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_SUB_IF):
-				OPC->_float = OPA->_int - (prvm_int_t) OPB->_float;
+				OPC->_float = ((prvm_vec_t) OPA->_int) - OPB->_float;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_SUB_FI):
 				OPC->_float = OPA->_float - (prvm_vec_t) OPB->_int;
@@ -853,7 +853,7 @@ prvm_eval_t *src;
 				OPC->_int = OPA->_int * OPB->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_MUL_IF):
-				OPC->_float = OPA->_int * (prvm_int_t) OPB->_float;
+				OPC->_float = ((prvm_vec_t) OPA->_int) * OPB->_float;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_MUL_FI):
 				OPC->_float = OPA->_float * (prvm_vec_t) OPB->_int;
@@ -875,7 +875,7 @@ prvm_eval_t *src;
 				OPC->_int = OPA->_int / OPB->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_DIV_IF):
-				OPC->_float = OPA->_int / (prvm_int_t) OPB->_float;
+				OPC->_float = ((prvm_vec_t) OPA->_int) / OPB->_float;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_DIV_FI):
 				OPC->_float = OPA->_float / (prvm_vec_t) OPB->_int;

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -517,7 +517,7 @@ prvm_eval_t *src;
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %"PRVM_PRIi"+%"PRVM_PRIi")\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
 					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
@@ -525,7 +525,7 @@ prvm_eval_t *src;
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to write to an out of bounds address %u+%i", prog->name, (unsigned int)OPB->_int, OPC->_int);
+					prog->error_cmd("%s attempted to write to an out of bounds address %"PRVM_PRIu"+%"PRVM_PRIi"", prog->name, OPB->_uint, OPC->_int);
 					goto cleanup;
 				}
 				ptr->_int = OPA->_int;
@@ -547,7 +547,7 @@ prvm_eval_t *src;
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %"PRVM_PRIi"+%"PRVM_PRIi")\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
 					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
@@ -555,7 +555,7 @@ prvm_eval_t *src;
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to write to an out of bounds address %u+%i", prog->name, (unsigned int)OPB->_int, OPC->_int);
+					prog->error_cmd("%s attempted to write to an out of bounds address %"PRVM_PRIu"+%"PRVM_PRIi"", prog->name, OPB->_uint, OPC->_int);
 					goto cleanup;
 				}
 				// refresh the garbage collection on the string - this guards
@@ -583,7 +583,7 @@ prvm_eval_t *src;
 					if (!cached_allowworldwrites)
 					{
 						PRE_ERROR();
-						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %i+%i)\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
+						VM_Warning(prog, "Attempted assignment to world.%s (edictnum 0 field %"PRVM_PRIi"+%"PRVM_PRIi")\n", PRVM_GetString(prog, PRVM_ED_FieldAtOfs(prog, ofs)->s_name), OPB->_int, OPC->_int);
 						// Perform entity write anyway.
 					}
 					ptr = (prvm_eval_t *)(cached_edictsfields + ofs);
@@ -591,7 +591,7 @@ prvm_eval_t *src;
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to write to an out of bounds address %u+%i", prog->name, (unsigned int)OPB->_int, OPC->_int);
+					prog->error_cmd("%s attempted to write to an out of bounds address %"PRVM_PRIu"+%"PRVM_PRIi"", prog->name, OPB->_uint, OPC->_int);
 					goto cleanup;
 				}
 				ptr->ivector[0] = OPA->ivector[0];
@@ -609,7 +609,7 @@ prvm_eval_t *src;
 				if (OPB->_uint >= cached_entityfields)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to address an invalid field (%i) in an edict", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to address an invalid field (%"PRVM_PRIu") in an edict", prog->name, OPB->_uint);
 					goto cleanup;
 				}
 #if 0
@@ -637,7 +637,7 @@ prvm_eval_t *src;
 				if (OPB->_uint >= cached_entityfields)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read an invalid field in an edict (%i)", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to read an invalid field in an edict (%"PRVM_PRIu")", prog->name, OPB->_uint);
 					goto cleanup;
 				}
 				ed = PRVM_PROG_TO_EDICT(OPA->edict);
@@ -653,7 +653,7 @@ prvm_eval_t *src;
 				if (OPB->_uint >= cached_entityfields)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read an invalid field in an edict (%i)", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to read an invalid field in an edict (%"PRVM_PRIu")", prog->name, OPB->_uint);
 					goto cleanup;
 				}
 				ed = PRVM_PROG_TO_EDICT(OPA->edict);
@@ -676,7 +676,7 @@ prvm_eval_t *src;
 				if (OPB->_uint >= cached_entityfields_2)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read an invalid field in an edict (%i)", prog->name, (int)OPB->_int);
+					prog->error_cmd("%s attempted to read an invalid field in an edict (%"PRVM_PRIu")", prog->name, OPB->_uint);
 					goto cleanup;
 				}
 				ed = PRVM_PROG_TO_EDICT(OPA->edict);
@@ -1140,7 +1140,7 @@ prvm_eval_t *src;
 				if ((unsigned int)OPA->_int < (unsigned int)st->operand[2] || (unsigned int)OPA->_int >= (unsigned int)st->operand[1])
 				{
 					PRE_ERROR();
-					prog->error_cmd("Progs boundcheck failed in %s, value is < %" PRVM_PRIi " or >= %" PRVM_PRIi, prog->name, OPC->_int, OPB->_int);
+					prog->error_cmd("Progs boundcheck failed in %s, value is < %"PRVM_PRIi" or >= %"PRVM_PRIi"", prog->name, OPC->_int, OPB->_int);
 					goto cleanup;
 				}
 				DISPATCH_OPCODE();
@@ -1161,7 +1161,7 @@ prvm_eval_t *src;
 				if (ofs >= cached_vmglobals)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)st->operand[0], OPB->_int);
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%"PRVM_PRIi"", prog->name, (unsigned int)st->operand[0], OPB->_int);
 					goto cleanup;
 				}
 				src = (prvm_eval_t *)&globals[ofs];
@@ -1172,7 +1172,7 @@ prvm_eval_t *src;
 				if (ofs >= cached_vmglobals)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)st->operand[0], OPB->_int);
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%"PRVM_PRIi"", prog->name, (unsigned int)st->operand[0], OPB->_int);
 					goto cleanup;
 				}
 				src = (prvm_eval_t *)&globals[ofs];
@@ -1189,7 +1189,7 @@ prvm_eval_t *src;
 				if (ofs >= cached_vmglobals_2)
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)st->operand[0], OPB->_int);
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%"PRVM_PRIi"", prog->name, (unsigned int)st->operand[0], OPB->_int);
 					goto cleanup;
 				}
 				src = (prvm_eval_t *)&globals[ofs];
@@ -1216,7 +1216,7 @@ prvm_eval_t *src;
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)OPA->_int, OPB->_int);
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%"PRVM_PRIi"", prog->name, (unsigned int)OPA->_int, OPB->_int);
 					goto cleanup;
 				}
 				OPC->_int = ptr->_int;
@@ -1236,7 +1236,7 @@ prvm_eval_t *src;
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)OPA->_int, OPB->_int);
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%"PRVM_PRIi"", prog->name, (unsigned int)OPA->_int, OPB->_int);
 					goto cleanup;
 				}
 				if(prvm_garbagecollection_enable.integer)
@@ -1258,7 +1258,7 @@ prvm_eval_t *src;
 				else
 				{
 					PRE_ERROR();
-					prog->error_cmd("%s attempted to read from an out of bounds address %u+%i", prog->name, (unsigned int)OPA->_int, OPB->_int);
+					prog->error_cmd("%s attempted to read from an out of bounds address %u+%"PRVM_PRIi"", prog->name, (unsigned int)OPA->_int, OPB->_int);
 					goto cleanup;
 				}
 				OPC->ivector[0] = ptr->ivector[0];

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -501,7 +501,7 @@ prvm_eval_t *src;
 			HANDLE_OPCODE(OP_STOREP_ENT):
 			HANDLE_OPCODE(OP_STOREP_FLD):		// integers
 			HANDLE_OPCODE(OP_STOREP_FNC):		// pointers
-				addr = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				addr = OPB->_uint + OPC->_uint;
 				if ((ofs = addr - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
 				{
 					// OK entity write.
@@ -531,7 +531,7 @@ prvm_eval_t *src;
 				ptr->_int = OPA->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_STOREP_S):
-				addr = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				addr = OPB->_uint + OPC->_uint;
 				if ((ofs = addr - cached_vmentity1start) < cached_entityfieldsarea_entityfields)
 				{
 					// OK entity write.
@@ -567,7 +567,7 @@ prvm_eval_t *src;
 				ptr->_int = OPA->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_STOREP_V):
-				addr = (prvm_uint_t)OPB->_int + (prvm_uint_t)OPC->_int;
+				addr = OPB->_uint + OPC->_uint;
 				if ((ofs = addr - cached_vmentity1start) < cached_entityfieldsarea_entityfields_2)
 				{
 					// OK entity write.
@@ -606,7 +606,7 @@ prvm_eval_t *src;
 					prog->error_cmd("%s attempted to address an out of bounds edict number", prog->name);
 					goto cleanup;
 				}
-				if ((prvm_uint_t)OPB->_int >= cached_entityfields)
+				if (OPB->_uint >= cached_entityfields)
 				{
 					PRE_ERROR();
 					prog->error_cmd("%s attempted to address an invalid field (%i) in an edict", prog->name, (int)OPB->_int);
@@ -634,7 +634,7 @@ prvm_eval_t *src;
 					prog->error_cmd("%s attempted to read an out of bounds edict number", prog->name);
 					goto cleanup;
 				}
-				if ((prvm_uint_t)OPB->_int >= cached_entityfields)
+				if (OPB->_uint >= cached_entityfields)
 				{
 					PRE_ERROR();
 					prog->error_cmd("%s attempted to read an invalid field in an edict (%i)", prog->name, (int)OPB->_int);
@@ -650,7 +650,7 @@ prvm_eval_t *src;
 					prog->error_cmd("%s attempted to read an out of bounds edict number", prog->name);
 					goto cleanup;
 				}
-				if ((prvm_uint_t)OPB->_int >= cached_entityfields)
+				if (OPB->_uint >= cached_entityfields)
 				{
 					PRE_ERROR();
 					prog->error_cmd("%s attempted to read an invalid field in an edict (%i)", prog->name, (int)OPB->_int);
@@ -673,7 +673,7 @@ prvm_eval_t *src;
 					prog->error_cmd("%s attempted to read an out of bounds edict number", prog->name);
 					goto cleanup;
 				}
-				if ((prvm_uint_t)OPB->_int >= cached_entityfields_2)
+				if (OPB->_uint >= cached_entityfields_2)
 				{
 					PRE_ERROR();
 					prog->error_cmd("%s attempted to read an invalid field in an edict (%i)", prog->name, (int)OPB->_int);
@@ -1202,7 +1202,7 @@ prvm_eval_t *src;
 			HANDLE_OPCODE(OP_LOADP_FLD):		// integers
 			HANDLE_OPCODE(OP_LOADP_FNC):		// pointers
 			HANDLE_OPCODE(OP_LOADP_I):
-				addr = (prvm_uint_t)OPA->_int + (prvm_uint_t)OPB->_int;
+				addr = OPA->_uint + OPB->_uint;
 				if ((ofs = addr - cached_vmentity0start) < cached_entityfieldsarea)
 				{
 					// OK entity write.
@@ -1222,7 +1222,7 @@ prvm_eval_t *src;
 				OPC->_int = ptr->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_LOADP_S):
-				addr = (prvm_uint_t)OPA->_int + (prvm_uint_t)OPB->_int;
+				addr = OPA->_uint + OPB->_uint;
 				if ((ofs = addr - cached_vmentity0start) < cached_entityfieldsarea)
 				{
 					// OK entity write.
@@ -1244,7 +1244,7 @@ prvm_eval_t *src;
 				OPC->_int = ptr->_int;
 				DISPATCH_OPCODE();
 			HANDLE_OPCODE(OP_LOADP_V):
-				addr = (prvm_uint_t)OPA->_int + (prvm_uint_t)OPB->_int;
+				addr = OPA->_uint + OPB->_uint;
 				if ((ofs = addr - cached_vmentity0start) < cached_entityfieldsarea_2)
 				{
 					// OK entity write.

--- a/prvm_execprogram.h
+++ b/prvm_execprogram.h
@@ -204,8 +204,8 @@ prvm_eval_t *src;
 	&&handle_OP_DIV_VF,
 
 	NULL,
-	NULL,
-	NULL,
+	&&handle_OP_RSHIFT_I,
+	&&handle_OP_LSHIFT_I,
 
 	&&handle_OP_GLOBALADDRESS,
 	&&handle_OP_ADD_PIW,
@@ -287,11 +287,31 @@ prvm_eval_t *src;
 	&&handle_OP_GLOAD_S,
 	&&handle_OP_GLOAD_FNC,
 	&&handle_OP_BOUNDCHECK,
+
 	NULL,
 	NULL,
 	NULL,
 	NULL,
-	&&handle_OP_GLOAD_V
+
+	&&handle_OP_GLOAD_V,
+
+	NULL,
+	NULL,
+
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+
+
+	NULL,
+	NULL,
+
+
+	&&handle_OP_LE_U,
+	&&handle_OP_LT_U,
+	&&handle_OP_DIV_U,
+	&&handle_OP_RSHIFT_U,
 	    };
 #define DISPATCH_OPCODE() \
     goto *dispatchtable[(++st)->op]
@@ -1206,6 +1226,33 @@ prvm_eval_t *src;
 				OPC->ivector[0] = ptr->ivector[0];
 				OPC->ivector[1] = ptr->ivector[1];
 				OPC->ivector[2] = ptr->ivector[2];
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_RSHIFT_I):
+				OPC->_int = OPA->_int >> OPB->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LSHIFT_I):
+				OPC->_int = OPA->_int << OPB->_int;
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LE_U):
+				OPC->_int = (OPA->_uint <= OPB->_uint);
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_LT_U):
+				OPC->_int = (OPA->_uint < OPB->_uint);
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_DIV_U):
+				if( OPB->_uint != 0 )
+				{
+					OPC->_uint = OPA->_uint / OPB->_uint;
+				}
+				else
+				{
+					PRE_ERROR();
+					VM_Warning(prog, "Attempted division of %u by zero\n", OPA->_uint);
+					OPC->_uint = 0;
+				}
+				DISPATCH_OPCODE();
+			HANDLE_OPCODE(OP_RSHIFT_U):
+				OPC->_uint = OPA->_uint >> OPB->_uint;
 				DISPATCH_OPCODE();
 
 #if !USE_COMPUTED_GOTOS

--- a/qtypes.h
+++ b/qtypes.h
@@ -49,12 +49,16 @@ typedef int64_t prvm_int_t;
 typedef uint64_t prvm_uint_t;
 #define PRVM_PRIi PRIi64
 #define PRVM_PRIu PRIu64
+#define PRVM_INT_MIN INT64_MIN
+#define PRVM_INT_MAX INT64_MAX
 #else
 typedef float prvm_vec_t;
 typedef int32_t prvm_int_t;
 typedef uint32_t prvm_uint_t;
 #define PRVM_PRIi PRIi32
 #define PRVM_PRIu PRIu32
+#define PRVM_INT_MIN INT32_MIN
+#define PRVM_INT_MAX INT32_MAX
 #endif
 typedef prvm_vec_t prvm_vec3_t[3];
 


### PR DESCRIPTION
Suggested by Spoike.

Fixes #236

Also fixing existing bugs in OP_DIV_* (no division by zero check, and inaccuracy in OP_DIV_IF).