### PR TITLE
fs: fix memory leak when zlib's inflateInit fails

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -2592,6 +2592,7 @@ static qfile_t *FS_OpenPackedFile (pack_t* pack, int pack_ind)
 		{
 			Con_Printf ("FS_OpenPackedFile: inflate init error (file: %s)\n", pfile->name);
 			FILEDESC_CLOSE(dup_handle);
+			Mem_Free(ztk);
 			Mem_Free(file);
 			return NULL;
 		}


### PR DESCRIPTION
`ztk` gets allocated few lines before, but not deallocated in case of an error.