### PR TITLE
Reverse the addstat case values to match the original Quake ordering

### DIFF
--- a/dpdefs/dpextensions.qc
+++ b/dpdefs/dpextensions.qc
@@ -2559,7 +2559,20 @@ string(string search, string replace, string subject) strireplace = #485;
 
 //EXT_CSQC
 // #232 void(float index, float type, .void field) SV_AddStat (EXT_CSQC)
+// index is the stat index
+// type is the EV_* field type
+// field is the name of the entity field
 void(float index, float type, ...) addstat = #232;
+
+// This is the list of types used by addstat
+float EV_STRING = 1;
+float EV_FLOAT = 2;
+float EV_VECTOR = 3;
+float EV_ENTITY = 4;
+float EV_FIELD = 5;
+float EV_FUNCTION = 6;
+float EV_POINTER = 7;
+float EV_INTEGER = 8;
 
 //ZQ_PAUSE
 //idea: ZQuake

--- a/svvm_cmds.c
+++ b/svvm_cmds.c
@@ -1746,13 +1746,13 @@ void VM_SV_UpdateCustomStats (client_t *client, prvm_edict_t *ent, sizebuf_t *ms
 			stats[i+3] = s[12] + s[13] * 256 + s[14] * 65536 + s[15] * 16777216;
 			break;
 		//float field sent as-is
-		case 8:
+		case 2:
 			// can't directly use PRVM_E_INT on the field because it may be PRVM_64 and a double is not the representation we want to send
 			u.f = PRVM_E_FLOAT(ent, vm_customstats[i].fieldoffset);
 			stats[i] = u.i;
 			break;
 		//integer value of float field
-		case 2:
+		case 8:
 			stats[i] = (int)PRVM_E_FLOAT(ent, vm_customstats[i].fieldoffset);
 			break;
 		default:


### PR DESCRIPTION
Reverse the addstat case values to match the original Quake ordering Of etype_t, and bring it in line with FTE. This means getstati and getstatf will now return the correct values.
Update dpextensions.qc with the EV_* (etype_t) constants.

This is backward incompatible with releases after 2008, by reversing 88124a20554e25662b6ff49e23d52de350701a80.