### PR TITLE
Change the condition for particle dynamic lights

### DIFF
--- a/cl_particles.c
+++ b/cl_particles.c
@@ -1635,7 +1635,7 @@ static void CL_NewParticlesFromEffectinfo(int effectnameindex, float pcount, con
 						Matrix4x4_CreateTranslate(&tempmatrix, originmaxs[0], originmaxs[1], originmaxs[2]);
 					else
 						Matrix4x4_CreateTranslate(&tempmatrix, center[0], center[1], center[2]);
-					if (info->lighttime > 0 && info->lightradiusfade > 0)
+					if (info->lighttime > 0 || info->lightradiusfade > 0)
 					{
 						// light flash (explosion, etc)
 						// called when effect starts


### PR DESCRIPTION
Changes the condition for creating a dynamic light for particles to either lighttime or lightradiusfade, rather then requiring both, because it caused particles with only lighttime to create no light.