### PR TITLE
Reset cls.demopaused to false when disconnecting

### DIFF
--- a/cl_main.c
+++ b/cl_main.c
@@ -463,7 +463,7 @@ void CL_DisconnectEx(qbool kicked, const char *fmt, ... )
 	cls.state = ca_disconnected;
 	cl.islocalgame = false;
 	cls.signon = 0;
-	cls.demoplayback = cls.timedemo = host.restless = false;
+	cls.demoplayback = cls.timedemo = host.restless = cls.demopaused = false;
 	Cvar_Callback(&vid_vsync); // might need to re-enable vsync
 
 	Cvar_Callback(&cl_netport);


### PR DESCRIPTION
Reset cls.demopaused to false, in CL_DisconnectEx, when the user disconnects so that subsequent use of playdemo works properly. This fixes #268 where demos stop playing or loading because pausedemo is still true/enabled.
Thanks to @Baker7 for the solution.