### PR TITLE
Revert PSKMODEL back to ACTRHEAD to correctly load PSK models.

### DIFF
--- a/model_shared.c
+++ b/model_shared.c
@@ -58,7 +58,7 @@ static modloader_t loader[] =
 	{NULL, "VBSP", 4, Mod_VBSP_Load},
 	{NULL, "ZYMOTICMODEL", 13, Mod_ZYMOTICMODEL_Load},
 	{NULL, "DARKPLACESMODEL", 16, Mod_DARKPLACESMODEL_Load},
-	{NULL, "PSKMODEL", 9, Mod_PSKMODEL_Load},
+	{NULL, "ACTRHEAD", 9, Mod_PSKMODEL_Load},
 	{NULL, "INTERQUAKEMODEL", 16, Mod_INTERQUAKEMODEL_Load},
 	{"map", NULL, 0, Mod_MAP_Load},
 	{NULL, NULL, 0, NULL}


### PR DESCRIPTION
Fixes #286 by reverting the header for PSK models back to `ACTRHEAD`, from `PSKMODEL`.