### PR TITLE
PRVM_GarbageCollection: Add range check on string garbage collection

### DIFF
--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -3820,7 +3820,6 @@ void PRVM_GarbageCollection(prvm_prog_t *prog)
 
 						if (num < 0 || num >= prog->numknownstrings)
 						{
-							Con_DPrintf("PRVM_GarbageCollection: string index %i is out of bounds\n", num);
 							continue;
 						}
 

--- a/prvm_edict.c
+++ b/prvm_edict.c
@@ -3817,6 +3817,13 @@ void PRVM_GarbageCollection(prvm_prog_t *prog)
 					if (s & PRVM_KNOWNSTRINGBASE)
 					{
 						prvm_int_t num = s - PRVM_KNOWNSTRINGBASE;
+
+						if (num < 0 || num >= prog->numknownstrings)
+						{
+							Con_DPrintf("PRVM_GarbageCollection: string index %i is out of bounds\n", num);
+							continue;
+						}
+
 						if (!prog->knownstrings[num])
 						{
 							// invalid


### PR DESCRIPTION
When using FTEQCC structs, it's possible for string variables to be outside the string global space. This can cause the garbage collector to segfault. This PR checks that the index is within bounds and will display a debug message and skip any that are not.

Resolves #293