### PR TITLE
Add Windows sdl-release build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,38 +8,38 @@ on:
   pull_request:
 
 jobs:
-  # linux-sdl-release:
-  #   runs-on: ubuntu-latest
-  #   container: debian:latest
-  #   steps:
-  #     # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
-  #     - name: Install dependencies
-  #       run: |
-  #         apt update
-  #         apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
+  linux-sdl-release:
+    runs-on: ubuntu-latest
+    container: debian:latest
+    steps:
+      # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
+      - name: Install dependencies
+        run: |
+          apt update
+          apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
 
-  #     - name: Fetch repository
-  #       uses: actions/checkout@v6
-  #       with:
-  #         # make `git describe` show the correct commit hash
-  #         fetch-depth: '0'
+      - name: Fetch repository
+        uses: actions/checkout@v6
+        with:
+          # make `git describe` show the correct commit hash
+          fetch-depth: '0'
 
-  #     - name: Compile
-  #       run: |
-  #         # prevent git complaining about dubious ownership of the repo
-  #         chown -R root:root .
-  #         # fail if `git describe` doesn't work (required for the buildstring)
-  #         git describe --always
-  #         # fail if there's any warnings
-  #         export CC="cc -Werror"
-  #         make sdl-release
+      - name: Compile
+        run: |
+          # prevent git complaining about dubious ownership of the repo
+          chown -R root:root .
+          # fail if `git describe` doesn't work (required for the buildstring)
+          git describe --always
+          # fail if there's any warnings
+          export CC="cc -Werror"
+          make sdl-release
 
-  #     - name: Upload Linux artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: Linux
-  #         path: |
-  #           darkplaces-sdl
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Linux
+          path: |
+            darkplaces-sdl
 
   windows-sdl-release:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,11 @@ jobs:
       - name: Setup MSYS2
         uses: msys2/setup-msys2@v2
         with:
-          msystem: mingw64
+          msystem: UCRT64
           install: >-
             make
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-SDL2
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,10 @@ jobs:
       - name: Build
         run: |
           make sdl-release
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows
+          path: |
+            darkplaces-sdl.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           # make `git describe` show the correct commit hash
           fetch-depth: '0'
+          persist-credentials: false
 
       - name: Compile
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,11 @@ jobs:
           install: >-
             make
             mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-libjpeg-turbo
+            mingw-w64-ucrt-x86_64-libpng
+            mingw-w64-ucrt-x86_64-libogg
+            mingw-w64-ucrt-x86_64-libvorbis
             mingw-w64-ucrt-x86_64-SDL2
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,41 +8,45 @@ on:
   pull_request:
 
 jobs:
-  linux-sdl-release:
-    runs-on: ubuntu-latest
-    container: debian:latest
-    steps:
-      # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
-      - name: Install dependencies
-        run: |
-          apt update
-          apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
+  # linux-sdl-release:
+  #   runs-on: ubuntu-latest
+  #   container: debian:latest
+  #   steps:
+  #     # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
+  #     - name: Install dependencies
+  #       run: |
+  #         apt update
+  #         apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
 
-      - name: Fetch repository
-        uses: actions/checkout@v6
-        with:
-          # make `git describe` show the correct commit hash
-          fetch-depth: '0'
+  #     - name: Fetch repository
+  #       uses: actions/checkout@v6
+  #       with:
+  #         # make `git describe` show the correct commit hash
+  #         fetch-depth: '0'
 
-      - name: Compile
-        run: |
-          # prevent git complaining about dubious ownership of the repo
-          chown -R root:root .
-          # fail if `git describe` doesn't work (required for the buildstring)
-          git describe --always
-          # fail if there's any warnings
-          export CC="cc -Werror"
-          make sdl-release
+  #     - name: Compile
+  #       run: |
+  #         # prevent git complaining about dubious ownership of the repo
+  #         chown -R root:root .
+  #         # fail if `git describe` doesn't work (required for the buildstring)
+  #         git describe --always
+  #         # fail if there's any warnings
+  #         export CC="cc -Werror"
+  #         make sdl-release
 
-      - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Linux
-          path: |
-            darkplaces-sdl
+  #     - name: Upload Linux artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: Linux
+  #         path: |
+  #           darkplaces-sdl
 
   windows-sdl-release:
     runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,9 @@ on:
   pull_request:
 
 jobs:
-  sdl-release:
+  linux-sdl-release:
     runs-on: ubuntu-latest
-    container:
-      image: debian:latest
+    container: debian:latest
     steps:
       # Must install git before checking out the repo otherwise github doesn't fetch the .git directory.
       - name: Install dependencies
@@ -20,7 +19,7 @@ jobs:
           apt install --yes build-essential git libjpeg-dev libsdl2-dev libcurl4-openssl-dev libpng-dev libfreetype-dev libvorbis-dev
 
       - name: Fetch repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6
         with:
           # make `git describe` show the correct commit hash
           fetch-depth: '0'
@@ -41,3 +40,24 @@ jobs:
           name: Linux
           path: |
             darkplaces-sdl
+
+  windows-sdl-release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          install: >-
+            make
+
+      - name: Build
+        run: |
+          make sdl-release


### PR DESCRIPTION
Add a new job to the build workflow to create a Windows SDL release.
Upgrade the Checkout task version.
Disable persist-credentials in both Checkout steps.